### PR TITLE
refactor(ui): PromptInput 组件

### DIFF
--- a/src/tests/promptInputKeys.test.ts
+++ b/src/tests/promptInputKeys.test.ts
@@ -118,23 +118,23 @@ test("renderBufferWithCursor draws the simulated cursor when focused", () => {
 });
 
 test("getPromptCursorPlacement targets the prompt row above divider and footer", () => {
-  const placement = getPromptCursorPlacement({ text: "hello", cursor: 5 }, 80, "> ", "Enter send");
+  const placement = getPromptCursorPlacement({ text: "hello", cursor: 5 }, 80, 2, "Enter send");
   assert.deepEqual(placement, { rowsUp: 3, column: 7 });
 });
 
 test("getPromptCursorPlacement targets the reserved row after a trailing newline", () => {
-  const placement = getPromptCursorPlacement({ text: "hello\n", cursor: 6 }, 80, "> ", "Enter send");
+  const placement = getPromptCursorPlacement({ text: "hello\n", cursor: 6 }, 80, 2, "Enter send");
   assert.deepEqual(placement, { rowsUp: 3, column: 2 });
 });
 
 test("getPromptCursorPlacement accounts for CJK character width", () => {
-  const placement = getPromptCursorPlacement({ text: "你好", cursor: 2 }, 80, "> ", "Enter send");
+  const placement = getPromptCursorPlacement({ text: "你好", cursor: 2 }, 80, 2, "Enter send");
   assert.equal(placement.column, 6);
 });
 
 test("getPromptCursorPlacement accounts for multiline buffer rows", () => {
-  const placement = getPromptCursorPlacement({ text: "hello\nworld", cursor: 11 }, 80, "> ", "Enter send");
+  const placement = getPromptCursorPlacement({ text: "hello\nworld", cursor: 11 }, 80, 2, "Enter send");
   assert.deepEqual(placement, { rowsUp: 3, column: 7 });
-  const middle = getPromptCursorPlacement({ text: "hello\nworld", cursor: 2 }, 80, "> ", "Enter send");
+  const middle = getPromptCursorPlacement({ text: "hello\nworld", cursor: 2 }, 80, 2, "Enter send");
   assert.deepEqual(middle, { rowsUp: 4, column: 4 });
 });

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -209,6 +209,11 @@ export function App({ projectRoot, version = "", onRestart }: AppProps): React.R
     sessionManager.interruptActiveSession();
   }, [sessionManager]);
 
+  const handleSubmit = useCallback(
+    (submission: PromptSubmission) => { void handlePrompt(submission); },
+    [handlePrompt]
+  );
+
   const handleSelectSession = useCallback(
     async (sessionId: string) => {
       sessionManager.setActiveSessionId(sessionId);
@@ -224,7 +229,12 @@ export function App({ projectRoot, version = "", onRestart }: AppProps): React.R
     [sessionManager]
   );
 
-  const screenWidth = useMemo(()=> columns ?? stdout?.columns ?? 80, [columns, stdout]);
+  const [stableColumns, setStableColumns] = useState(columns);
+  useEffect(() => {
+    const timer = setTimeout(() => setStableColumns(columns), 100);
+    return () => clearTimeout(timer);
+  }, [columns]);
+  const screenWidth = useMemo(() => stableColumns ?? stdout?.columns ?? 80, [stableColumns, stdout]);
   const promptHistory = useMemo(() => {
     return messages
       .filter((message) => message.role === "user" && typeof message.content === "string")
@@ -336,8 +346,9 @@ export function App({ projectRoot, version = "", onRestart }: AppProps): React.R
           promptHistory={promptHistory}
           busy={busy}
           loadingText={loadingText}
-          onSubmit={(submission) => void handlePrompt(submission)}
+          onSubmit={handleSubmit}
           onInterrupt={handleInterrupt}
+          placeholder='Type your message...'
         />
       )}
     </Box>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -59,6 +59,19 @@ export function App({ projectRoot, version = "", onRestart }: AppProps): React.R
   const [showWelcome, setShowWelcome] = useState(true);
   const [, setNowTick] = useState(0);
 
+  const rootDirectoryWarning = useMemo(() => {
+    try {
+      const workspaceRealPath = fs.realpathSync(projectRoot);
+      const rootRealPath = fs.realpathSync(os.homedir());
+      if (workspaceRealPath === rootRealPath) {
+        return 'Warning: You are running DeepCode CLI in the root directory. Your entire folder structure will be used for context. It is strongly recommended to run in a project-specific directory.';
+      }
+      return null;
+    } catch {
+      return 'Could not verify the current directory due to a file system error.';
+    }
+  }, [projectRoot]);
+
   const messagesRef = useRef<SessionMessage[]>([]);
   messagesRef.current = messages;
 
@@ -305,6 +318,7 @@ export function App({ projectRoot, version = "", onRestart }: AppProps): React.R
                 skills={skills}
                 version={version}
                 width={screenWidth}
+                rootDirectoryWarning={rootDirectoryWarning}
               />
             );
           }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Box, Static, Text, useApp, useStdout } from "ink";
+import { Box, Static, Text, useApp, useStdout, useWindowSize } from "ink";
 import chalk from "chalk";
 import * as fs from "fs";
 import * as os from "os";
@@ -43,6 +43,7 @@ type AppProps = {
 export function App({ projectRoot, version = "", onRestart }: AppProps): React.ReactElement {
   const { exit } = useApp();
   const { stdout, write } = useStdout();
+  const { columns } = useWindowSize();
   const [view, setView] = useState<View>("chat");
   const [busy, setBusy] = useState(false);
   const [skills, setSkills] = useState<SkillInfo[]>([]);
@@ -116,6 +117,8 @@ export function App({ projectRoot, version = "", onRestart }: AppProps): React.R
     }
   }
 
+  const writeRef = useRef(write);
+  writeRef.current = write;
   const handlePrompt = useCallback(
     async (submission: PromptSubmission) => {
       if (submission.command === "exit") {
@@ -141,7 +144,7 @@ export function App({ projectRoot, version = "", onRestart }: AppProps): React.R
         if (onRestart) {
           onRestart();
         } else {
-          write("\u001B[2J\u001B[3J\u001B[H");
+          writeRef.current("\u001B[2J\u001B[3J\u001B[H");
           sessionManager.setActiveSessionId(null);
           setMessages([]);
           setStatusLine("");
@@ -199,7 +202,7 @@ export function App({ projectRoot, version = "", onRestart }: AppProps): React.R
         setRunningProcesses(null);
       }
     },
-    [exit, onRestart, sessionManager, write]
+    [exit, onRestart, sessionManager]
   );
 
   const handleInterrupt = useCallback(() => {
@@ -221,7 +224,7 @@ export function App({ projectRoot, version = "", onRestart }: AppProps): React.R
     [sessionManager]
   );
 
-  const screenWidth = stdout?.columns ?? 80;
+  const screenWidth = useMemo(()=> columns ?? stdout?.columns ?? 80, [columns, stdout]);
   const promptHistory = useMemo(() => {
     return messages
       .filter((message) => message.role === "user" && typeof message.content === "string")
@@ -236,9 +239,12 @@ export function App({ projectRoot, version = "", onRestart }: AppProps): React.R
   const shouldShowQuestionPrompt = Boolean(
     pendingQuestion && !dismissedQuestionIds.has(pendingQuestion.messageId)
   );
-  const loadingText = busy
-    ? buildLoadingText({ progress: streamProgress, processes: runningProcesses, now: Date.now() })
-    : null;
+  const loadingText = useMemo(
+    () => busy
+      ? buildLoadingText({ progress: streamProgress, processes: runningProcesses, now: Date.now() })
+      : null,
+    [busy, streamProgress, runningProcesses]
+  );
   const welcomeSettings = useMemo(() => resolveCurrentSettings(), []);
   const welcomeItem: SessionMessage = useMemo(() => ({
     id: "__welcome__",
@@ -277,7 +283,7 @@ export function App({ projectRoot, version = "", onRestart }: AppProps): React.R
   }, [pendingQuestion]);
 
   return (
-    <Box flexDirection="column" width={screenWidth}>
+    <Box flexDirection="column" width={screenWidth} minWidth={80} overflowX={'visible'}>
       <Static items={staticItems}>
         {(item) => {
           if (item.id === "__welcome__") {
@@ -325,6 +331,7 @@ export function App({ projectRoot, version = "", onRestart }: AppProps): React.R
         />
       ) : isExiting ? null : (
         <PromptInput
+          screenWidth={screenWidth}
           skills={skills}
           promptHistory={promptHistory}
           busy={busy}

--- a/src/ui/MessageView.tsx
+++ b/src/ui/MessageView.tsx
@@ -17,9 +17,9 @@ export function MessageView({ message }: Props): React.ReactElement | null {
     const text = message.content || "(no content)";
     return (
       <Box flexDirection="column" marginY={0}>
-        <Text color="green">{`> ${text}`}</Text>
+        <Text color="#229ac3">{`> ${text}`}</Text>
         {Array.isArray(message.contentParams) && message.contentParams.length > 0 ? (
-          <Text color="green">{`  📎 ${message.contentParams.length} image attachment(s)`}</Text>
+          <Text color="#229ac3">{`  📎 ${message.contentParams.length} image attachment(s)`}</Text>
         ) : null}
       </Box>
     );

--- a/src/ui/PromptInput.tsx
+++ b/src/ui/PromptInput.tsx
@@ -53,11 +53,31 @@ type Props = {
   busy: boolean;
   loadingText?: string | null;
   disabled?: boolean;
+  placeholder?: string;
   onSubmit: (submission: PromptSubmission) => void;
   onInterrupt: () => void;
 };
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const PROMPT_PREFIX_WIDTH = 2;
+
+const PromptPrefixLine = React.memo(function PromptPrefixLine({ busy }: { busy: boolean }): React.ReactElement {
+  const [spinnerIndex, setSpinnerIndex] = useState(0);
+
+  useEffect(() => {
+    if (!busy) {
+      setSpinnerIndex(0);
+      return;
+    }
+    const timer = setInterval(() => {
+      setSpinnerIndex((index) => (index + 1) % SPINNER_FRAMES.length);
+    }, 80);
+    return () => clearInterval(timer);
+  }, [busy]);
+
+  const prefix = busy ? `${SPINNER_FRAMES[spinnerIndex]} ` : "> ";
+  return <Text color={busy ? "yellow" : "green"}>{prefix}</Text>;
+});
 
 export const PromptInput = React.memo(function PromptInput({
   skills,
@@ -66,6 +86,7 @@ export const PromptInput = React.memo(function PromptInput({
   busy,
   loadingText,
   disabled,
+  placeholder,
   onSubmit,
   onInterrupt
 }: Props): React.ReactElement {
@@ -82,7 +103,6 @@ export const PromptInput = React.memo(function PromptInput({
   const [historyCursor, setHistoryCursor] = useState(-1);
   const [draftBeforeHistory, setDraftBeforeHistory] = useState<string | null>(null);
   const [hasTerminalFocus, setHasTerminalFocus] = useState(true);
-  const [spinnerIndex, setSpinnerIndex] = useState(0);
   const lastCtrlDAt = React.useRef<number>(0);
 
   const slashItems = React.useMemo(() => buildSlashCommands(skills), [skills]);
@@ -90,7 +110,6 @@ export const PromptInput = React.memo(function PromptInput({
   const slashMenu = showSkillsDropdown ? [] : slashToken ? filterSlashCommands(slashItems, slashToken) : [];
   const showMenu = slashMenu.length > 0;
   const promptHistoryKey = React.useMemo(() => promptHistory.join("\0"), [promptHistory]);
-  const promptPrefix = busy ? `${SPINNER_FRAMES[spinnerIndex]} ` : "> ";
   const footerText = statusMessage
     ? statusMessage
     : busy
@@ -99,23 +118,12 @@ export const PromptInput = React.memo(function PromptInput({
         : "esc to interrupt · ctrl+c to cancel input"
       : "enter send · shift+enter newline · ctrl+v image · / commands · ctrl+d exit";
   const cursorPlacement = React.useMemo(
-    () => getPromptCursorPlacement(buffer, screenWidth, promptPrefix, footerText),
-    [buffer, footerText, promptPrefix, screenWidth]
+    () => getPromptCursorPlacement(buffer, screenWidth, PROMPT_PREFIX_WIDTH, footerText),
+    [buffer, footerText, screenWidth]
   );
 
   useTerminalFocusReporting(stdout, !disabled);
   usePromptTerminalCursor(stdout, cursorPlacement, !disabled);
-
-  useEffect(() => {
-    if (!busy) {
-      setSpinnerIndex(0);
-      return;
-    }
-    const timer = setInterval(() => {
-      setSpinnerIndex((index) => (index + 1) % SPINNER_FRAMES.length);
-    }, 80);
-    return () => clearInterval(timer);
-  }, [busy]);
 
   useEffect(() => {
     if (!showMenu) {
@@ -589,12 +597,12 @@ export const PromptInput = React.memo(function PromptInput({
           {slashMenu.length > 8 ? <Text dimColor>… {slashMenu.length - 8} more</Text> : null}
         </Box>
       ) : null}
-      <Text dimColor>{divider}</Text>
+      <Text dimColor wrap="truncate-end">{divider}</Text>
       <Box>
-        <Text color={busy ? "yellow" : "green"}>{promptPrefix}</Text>
-        <Text>{renderBufferWithCursor(buffer, !disabled && hasTerminalFocus)}</Text>
+        <PromptPrefixLine busy={busy} />
+        <Text>{renderBufferWithCursor(buffer, !disabled && hasTerminalFocus, placeholder)}</Text>
       </Box>
-      <Text dimColor>{divider}</Text>
+      <Text dimColor wrap="truncate-end">{divider}</Text>
       <Box>
         <Text dimColor>{footerText}</Text>
       </Box>
@@ -655,12 +663,17 @@ export function isClearImageAttachmentsShortcut(input: string, key: Pick<InputKe
   return key.ctrl && (input === "x" || input === "X");
 }
 
-export function renderBufferWithCursor(state: PromptBufferState, isFocused: boolean): string {
+export function renderBufferWithCursor(state: PromptBufferState, isFocused: boolean, placeholder?: string): string {
   const text = state.text || "";
   const cursor = Math.max(0, Math.min(state.cursor, text.length));
   const before = text.slice(0, cursor);
   const at = text[cursor];
   const after = text.slice(cursor + 1);
+
+  if (text.length === 0 && placeholder) {
+    return chalk.dim("  " +placeholder);
+  }
+
   if (!isFocused) {
     return text.endsWith("\n") ? `${text} ` : text;
   }

--- a/src/ui/PromptInput.tsx
+++ b/src/ui/PromptInput.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { Box, Text, useApp, useStdin, useStdout } from "ink";
+import React, {useEffect, useMemo, useState} from "react";
+import { Box, Text, useApp, useStdout } from "ink";
 import chalk from "chalk";
 import {
   EMPTY_BUFFER,
@@ -31,6 +31,14 @@ import {
 import { readClipboardImage } from "./clipboard";
 import type { SkillInfo } from "../session";
 
+// Re-exported from prompt modules for backward compatibility
+export { useTerminalInput, parseTerminalInput } from "./prompt";
+export type { InputKey } from "./prompt";
+
+import { useTerminalInput, parseTerminalInput } from "./prompt";
+import type { InputKey } from "./prompt";
+import { usePromptTerminalCursor, useTerminalFocusReporting, getPromptCursorPlacement } from "./prompt/cursor";
+
 export type PromptSubmission = {
   text: string;
   imageUrls: string[];
@@ -40,6 +48,7 @@ export type PromptSubmission = {
 
 type Props = {
   skills: SkillInfo[];
+  screenWidth: number;
   promptHistory: string[];
   busy: boolean;
   loadingText?: string | null;
@@ -48,43 +57,11 @@ type Props = {
   onInterrupt: () => void;
 };
 
-const BACKSPACE_BYTES = new Set(["", ""]);
-const FORWARD_DELETE_SEQUENCES = new Set(["[3~", "[P"]);
-const HOME_SEQUENCES = new Set(["[H", "[1~", "[7~", "OH"]);
-const END_SEQUENCES = new Set(["[F", "[4~", "[8~", "OF"]);
-const SHIFT_RETURN_SEQUENCES = new Set(["\r", "[13;2u"]);
-const META_RETURN_SEQUENCES = new Set(["[13;3u", "[13;4u"]);
-const CTRL_LEFT_SEQUENCES = new Set(["[1;5D", "[5D"]);
-const CTRL_RIGHT_SEQUENCES = new Set(["[1;5C", "[5C"]);
-const META_LEFT_SEQUENCES = new Set(["[1;3D", "[3D", "b"]);
-const META_RIGHT_SEQUENCES = new Set(["[1;3C", "[3C", "f"]);
-const TERMINAL_FOCUS_IN = "[I";
-const TERMINAL_FOCUS_OUT = "[O";
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
-export type InputKey = {
-  upArrow: boolean;
-  downArrow: boolean;
-  leftArrow: boolean;
-  rightArrow: boolean;
-  home: boolean;
-  end: boolean;
-  pageDown: boolean;
-  pageUp: boolean;
-  return: boolean;
-  escape: boolean;
-  ctrl: boolean;
-  shift: boolean;
-  tab: boolean;
-  backspace: boolean;
-  delete: boolean;
-  meta: boolean;
-  focusIn: boolean;
-  focusOut: boolean;
-};
-
-export function PromptInput({
+export const PromptInput = React.memo(function PromptInput({
   skills,
+  screenWidth,
   promptHistory,
   busy,
   loadingText,
@@ -94,7 +71,6 @@ export function PromptInput({
 }: Props): React.ReactElement {
   const { exit } = useApp();
   const { stdout } = useStdout();
-  const screenWidth = Math.max(20, stdout?.columns ?? 80);
   const [buffer, setBuffer] = useState<PromptBufferState>(EMPTY_BUFFER);
   const [imageUrls, setImageUrls] = useState<string[]>([]);
   const [selectedSkills, setSelectedSkills] = useState<SkillInfo[]>([]);
@@ -107,13 +83,13 @@ export function PromptInput({
   const [draftBeforeHistory, setDraftBeforeHistory] = useState<string | null>(null);
   const [hasTerminalFocus, setHasTerminalFocus] = useState(true);
   const [spinnerIndex, setSpinnerIndex] = useState(0);
-  const lastCtrlDAt = useRef<number>(0);
+  const lastCtrlDAt = React.useRef<number>(0);
 
-  const slashItems = useMemo(() => buildSlashCommands(skills), [skills]);
+  const slashItems = React.useMemo(() => buildSlashCommands(skills), [skills]);
   const slashToken = getCurrentSlashToken(buffer);
   const slashMenu = showSkillsDropdown ? [] : slashToken ? filterSlashCommands(slashItems, slashToken) : [];
   const showMenu = slashMenu.length > 0;
-  const promptHistoryKey = useMemo(() => promptHistory.join("\0"), [promptHistory]);
+  const promptHistoryKey = React.useMemo(() => promptHistory.join("\0"), [promptHistory]);
   const promptPrefix = busy ? `${SPINNER_FRAMES[spinnerIndex]} ` : "> ";
   const footerText = statusMessage
     ? statusMessage
@@ -122,7 +98,7 @@ export function PromptInput({
         ? loadingText
         : "esc to interrupt · ctrl+c to cancel input"
       : "enter send · shift+enter newline · ctrl+v image · / commands · ctrl+d exit";
-  const cursorPlacement = useMemo(
+  const cursorPlacement = React.useMemo(
     () => getPromptCursorPlacement(buffer, screenWidth, promptPrefix, footerText),
     [buffer, footerText, promptPrefix, screenWidth]
   );
@@ -422,7 +398,7 @@ export function PromptInput({
       return;
     }
 
-    if (input.startsWith("")) {
+    if (input.startsWith("\u001B")) {
       // Unhandled escape sequence (e.g. function keys); ignore to avoid inserting garbage.
       return;
     }
@@ -552,7 +528,7 @@ export function PromptInput({
     setBuffer((state) => removeCurrentSlashToken(state));
   }
 
-  const divider = "─".repeat(screenWidth);
+  const divider = useMemo(() => "─".repeat(screenWidth), [screenWidth]);
   const visibleSkillStart = Math.min(
     Math.max(0, skillsDropdownIndex - 7),
     Math.max(0, skills.length - 8)
@@ -560,7 +536,7 @@ export function PromptInput({
   const visibleSkills = skills.slice(visibleSkillStart, visibleSkillStart + 8);
 
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" width={screenWidth}>
       {imageUrls.length > 0 ? (
         <Box>
           <Text color="magenta">{formatImageAttachmentStatus(imageUrls.length)}</Text>
@@ -624,7 +600,7 @@ export function PromptInput({
       </Box>
     </Box>
   );
-}
+});
 
 export const IMAGE_ATTACHMENT_CLEAR_HINT = "ctrl+x clear images";
 
@@ -679,207 +655,6 @@ export function isClearImageAttachmentsShortcut(input: string, key: Pick<InputKe
   return key.ctrl && (input === "x" || input === "X");
 }
 
-type CursorPlacement = {
-  rowsUp: number;
-  column: number;
-};
-
-type WriteFn = (
-  chunk: string | Uint8Array,
-  encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
-  callback?: (error?: Error | null) => void
-) => boolean;
-
-function usePromptTerminalCursor(
-  stdout: NodeJS.WriteStream | undefined,
-  placement: CursorPlacement,
-  isActive: boolean
-): void {
-  const directWriteRef = useRef<((data: string) => void) | null>(null);
-  const activePlacementRef = useRef<CursorPlacement | null>(null);
-
-  useLayoutEffect(() => {
-    if (!stdout?.isTTY) {
-      return;
-    }
-
-    const stream = stdout as NodeJS.WriteStream & { write: WriteFn };
-    const originalWrite = stream.write;
-    const directWrite = (data: string) => {
-      originalWrite.call(stdout, data);
-    };
-    const restorePromptCursor = () => {
-      const activePlacement = activePlacementRef.current;
-      if (!activePlacement) {
-        return;
-      }
-      directWrite("\r" + cursorDown(activePlacement.rowsUp) + hideCursor());
-      activePlacementRef.current = null;
-    };
-    const patchedWrite: WriteFn = (...args) => {
-      restorePromptCursor();
-      return originalWrite.apply(stdout, args);
-    };
-
-    directWriteRef.current = directWrite;
-    stream.write = patchedWrite;
-
-    return () => {
-      restorePromptCursor();
-      stream.write = originalWrite;
-      directWriteRef.current = null;
-    };
-  }, [stdout]);
-
-  useLayoutEffect(() => {
-    if (!isActive || !stdout?.isTTY) {
-      return;
-    }
-
-    const directWrite = directWriteRef.current;
-    if (!directWrite) {
-      return;
-    }
-
-    directWrite(showCursor() + cursorUp(placement.rowsUp) + "\r" + cursorForward(placement.column));
-    activePlacementRef.current = placement;
-
-    return () => {
-      const activePlacement = activePlacementRef.current;
-      if (!activePlacement) {
-        return;
-      }
-      directWrite("\r" + cursorDown(activePlacement.rowsUp) + hideCursor());
-      activePlacementRef.current = null;
-    };
-  }, [isActive, placement.column, placement.rowsUp, stdout]);
-}
-
-function useTerminalFocusReporting(stdout: NodeJS.WriteStream | undefined, isActive: boolean): void {
-  useLayoutEffect(() => {
-    if (!isActive || !stdout?.isTTY) {
-      return;
-    }
-
-    stdout.write(enableTerminalFocusReporting());
-    return () => {
-      stdout.write(disableTerminalFocusReporting());
-    };
-  }, [isActive, stdout]);
-}
-
-export function getPromptCursorPlacement(
-  state: PromptBufferState,
-  screenWidth: number,
-  promptPrefix: string,
-  footerText: string
-): CursorPlacement {
-  const width = Math.max(1, screenWidth);
-  const cursor = Math.max(0, Math.min(state.cursor, state.text.length));
-  const beforeCursor = state.text.slice(0, cursor);
-  const at = state.text[cursor];
-  const displayText = beforeCursor + (typeof at === "undefined" || at === "\n" ? " " : at) +
-    (at === "\n" ? "\n" : "") + (typeof at === "undefined" ? "" : state.text.slice(cursor + 1));
-
-  const cursorPosition = measureTextPosition(beforeCursor, width, textWidth(promptPrefix));
-  const promptRows = measureTextRows(displayText, width, textWidth(promptPrefix));
-  const footerRows = 1 + measureTextRows(footerText, width, 0);
-
-  return {
-    rowsUp: (promptRows - 1 - cursorPosition.row) + footerRows + 1,
-    column: cursorPosition.column
-  };
-}
-
-function measureTextRows(text: string, width: number, initialColumn: number): number {
-  return measureTextPosition(text, width, initialColumn).row + 1;
-}
-
-function measureTextPosition(text: string, width: number, initialColumn: number): { row: number; column: number } {
-  let row = 0;
-  let column = Math.min(initialColumn, width - 1);
-
-  for (const char of Array.from(text)) {
-    if (char === "\n") {
-      row++;
-      column = Math.min(initialColumn, width - 1);
-      continue;
-    }
-
-    const charColumns = textWidth(char);
-    if (column + charColumns > width) {
-      row++;
-      column = Math.min(initialColumn, width - 1);
-    }
-    column += charColumns;
-    if (column >= width) {
-      row++;
-      column = Math.min(initialColumn, width - 1);
-    }
-  }
-
-  return { row, column };
-}
-
-function textWidth(value: string): number {
-  let width = 0;
-  for (const char of Array.from(value.normalize())) {
-    width += characterWidth(char);
-  }
-  return width;
-}
-
-function characterWidth(char: string): number {
-  const codePoint = char.codePointAt(0) ?? 0;
-  if (codePoint === 0 || codePoint < 32 || (codePoint >= 0x7f && codePoint < 0xa0)) {
-    return 0;
-  }
-  if (codePoint >= 0x300 && codePoint <= 0x36f) {
-    return 0;
-  }
-  if (
-    (codePoint >= 0x1100 && codePoint <= 0x115f) ||
-    (codePoint >= 0x2e80 && codePoint <= 0xa4cf) ||
-    (codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
-    (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
-    (codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
-    (codePoint >= 0xfe30 && codePoint <= 0xfe6f) ||
-    (codePoint >= 0xff00 && codePoint <= 0xff60) ||
-    (codePoint >= 0xffe0 && codePoint <= 0xffe6)
-  ) {
-    return 2;
-  }
-  return 1;
-}
-
-function cursorUp(rows: number): string {
-  return rows > 0 ? `\u001B[${rows}A` : "";
-}
-
-function cursorDown(rows: number): string {
-  return rows > 0 ? `\u001B[${rows}B` : "";
-}
-
-function cursorForward(columns: number): string {
-  return columns > 0 ? `\u001B[${columns}C` : "";
-}
-
-function showCursor(): string {
-  return "\u001B[?25h";
-}
-
-function hideCursor(): string {
-  return "\u001B[?25l";
-}
-
-function enableTerminalFocusReporting(): string {
-  return "\u001B[?1004h";
-}
-
-function disableTerminalFocusReporting(): string {
-  return "\u001B[?1004l";
-}
-
 export function renderBufferWithCursor(state: PromptBufferState, isFocused: boolean): string {
   const text = state.text || "";
   const cursor = Math.max(0, Math.min(state.cursor, text.length));
@@ -897,105 +672,4 @@ export function renderBufferWithCursor(state: PromptBufferState, isFocused: bool
     return before + chalk.inverse(" ") + "\n" + after;
   }
   return before + chalk.inverse(at) + after;
-}
-
-export function useTerminalInput(
-  inputHandler: (input: string, key: InputKey) => void,
-  options: { isActive?: boolean } = {}
-): void {
-  const { stdin, setRawMode } = useStdin();
-  const isActive = options.isActive ?? true;
-
-  useEffect(() => {
-    if (!isActive) {
-      return;
-    }
-    setRawMode(true);
-    return () => {
-      setRawMode(false);
-    };
-  }, [isActive, setRawMode]);
-
-  useEffect(() => {
-    if (!isActive) {
-      return;
-    }
-    const handleData = (data: Buffer | string) => {
-      const { input, key } = parseTerminalInput(data);
-      inputHandler(input, key);
-    };
-
-    stdin?.on("data", handleData);
-    return () => {
-      stdin?.off("data", handleData);
-    };
-  }, [isActive, stdin, inputHandler]);
-}
-
-export function parseTerminalInput(data: Buffer | string): { input: string; key: InputKey } {
-  const raw = String(data);
-  let input = raw;
-  const key: InputKey = {
-    upArrow: raw === "\u001B[A",
-    downArrow: raw === "\u001B[B",
-    leftArrow: raw === "\u001B[D" || CTRL_LEFT_SEQUENCES.has(raw) || META_LEFT_SEQUENCES.has(raw),
-    rightArrow: raw === "\u001B[C" || CTRL_RIGHT_SEQUENCES.has(raw) || META_RIGHT_SEQUENCES.has(raw),
-    home: HOME_SEQUENCES.has(raw),
-    end: END_SEQUENCES.has(raw),
-    pageDown: raw === "\u001B[6~",
-    pageUp: raw === "\u001B[5~",
-    return: raw === "\r" || SHIFT_RETURN_SEQUENCES.has(raw) || META_RETURN_SEQUENCES.has(raw),
-    escape: raw === "\u001B",
-    ctrl: CTRL_LEFT_SEQUENCES.has(raw) || CTRL_RIGHT_SEQUENCES.has(raw),
-    shift: SHIFT_RETURN_SEQUENCES.has(raw),
-    tab: raw === "\t" || raw === "\u001B[Z",
-    backspace: BACKSPACE_BYTES.has(raw),
-    delete: FORWARD_DELETE_SEQUENCES.has(raw),
-    meta: META_LEFT_SEQUENCES.has(raw) || META_RIGHT_SEQUENCES.has(raw) || META_RETURN_SEQUENCES.has(raw),
-    focusIn: raw === TERMINAL_FOCUS_IN,
-    focusOut: raw === TERMINAL_FOCUS_OUT
-  };
-
-  if (input <= "\u001A" && !key.return) {
-    input = String.fromCharCode(input.charCodeAt(0) + "a".charCodeAt(0) - 1);
-    key.ctrl = true;
-  }
-
-  const isKnownEscapeSequence =
-    key.upArrow ||
-    key.downArrow ||
-    key.leftArrow ||
-    key.rightArrow ||
-    key.home ||
-    key.end ||
-    key.pageDown ||
-    key.pageUp ||
-    key.tab ||
-    key.delete ||
-    key.return ||
-    key.ctrl ||
-    key.meta ||
-    key.focusIn ||
-    key.focusOut;
-
-  if (raw.startsWith("\u001B")) {
-    input = raw.slice(1);
-    key.meta = key.meta || !isKnownEscapeSequence;
-  }
-
-  const isLatinUppercase = input >= "A" && input <= "Z";
-  const isCyrillicUppercase = input >= "А" && input <= "Я";
-  if (input.length === 1 && (isLatinUppercase || isCyrillicUppercase)) {
-    key.shift = true;
-  }
-
-  if (key.tab && input === "[Z") {
-    key.shift = true;
-  }
-
-  if (key.tab || key.backspace || key.delete) {
-    input = "";
-  }
-
-  return { input, key };
 }

--- a/src/ui/WelcomeScreen.tsx
+++ b/src/ui/WelcomeScreen.tsx
@@ -1,7 +1,7 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useState} from "react";
 import { Box, Text } from "ink";
-import * as os from "os";
-import * as path from "path";
+import * as os from "node:os";
+import path from 'node:path';
 import type { SkillInfo } from "../session";
 import type { ResolvedDeepcodingSettings } from "../settings";
 import {
@@ -17,6 +17,7 @@ type WelcomeScreenProps = {
   skills: SkillInfo[];
   version: string;
   width: number;
+  rootDirectoryWarning: string | null;
 };
 
 const TITLE_PANEL_WIDTH = 70;
@@ -36,7 +37,8 @@ export function WelcomeScreen({
   settings,
   skills,
   version,
-  width
+  width,
+  rootDirectoryWarning
 }: WelcomeScreenProps): React.ReactElement {
   const tips = useMemo(() => buildWelcomeTips(skills), [skills]);
   const [tipIndex] = useState(() => randomTipIndex(tips.length));
@@ -88,13 +90,21 @@ export function WelcomeScreen({
         </Box>
       </Box>
 
-      {tip ? (
-        <Box marginTop={1}>
-          <Text dimColor>
-            Tips: {tip.label} - {tip.description}
-          </Text>
-        </Box>
-      ) : null}
+      <Box flexDirection='column' width={panelWidth} paddingX={1}>
+        {tip ? (
+          <Box marginTop={1}>
+            <Text dimColor>
+              Tips: {tip.label} - {tip.description}
+            </Text>
+          </Box>
+        ) : null}
+
+        {rootDirectoryWarning ? (
+          <Box marginTop={1} borderStyle='round' borderColor='yellow' paddingX={1}>
+            <Text color="yellow">{rootDirectoryWarning}</Text>
+          </Box>
+        ) : null}
+      </Box>
     </Box>
   );
 }

--- a/src/ui/WelcomeScreen.tsx
+++ b/src/ui/WelcomeScreen.tsx
@@ -98,12 +98,6 @@ export function WelcomeScreen({
             </Text>
           </Box>
         ) : null}
-
-        {rootDirectoryWarning ? (
-          <Box marginTop={1} borderStyle='round' borderColor='yellow' paddingX={1}>
-            <Text color="yellow">{rootDirectoryWarning}</Text>
-          </Box>
-        ) : null}
       </Box>
     </Box>
   );

--- a/src/ui/exitSummary.ts
+++ b/src/ui/exitSummary.ts
@@ -82,7 +82,7 @@ export function buildExitSummaryText(input: ExitSummaryInput): string {
 
   const rows: string[] = [
     "",
-    `  ${header}`,
+    `${header}`,
     "",
   ];
 
@@ -105,8 +105,8 @@ export function buildExitSummaryText(input: ExitSummaryInput): string {
       padLeft("Input Tokens", colInput) +
       padLeft("Output Tokens", colOutput) +
       padLeft("Cached Tokens", colCached);
-    rows.push(`  ${chalk.bold(headerRow)}`);
-    rows.push(`  ${divider}`);
+    rows.push(chalk.bold(headerRow));
+    rows.push(divider);
 
     const reqsStr = String(assistantCount).padStart(colReqs);
     const inputStr = formatNumber(usage.promptTokens).padStart(colInput);
@@ -118,7 +118,7 @@ export function buildExitSummaryText(input: ExitSummaryInput): string {
       padRight(chalk.yellow(inputStr), colInput) +
       padRight(chalk.yellow(outputStr), colOutput) +
       padRight(chalk.yellow(cachedStr), colCached);
-    rows.push(`  ${dataRow}`);
+    rows.push(dataRow);
 
     rows.push("");
   }

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -11,13 +11,13 @@ export {
   toggleSkillSelection,
   removeCurrentSlashToken,
   isClearImageAttachmentsShortcut,
-  getPromptCursorPlacement,
   renderBufferWithCursor,
   useTerminalInput,
   parseTerminalInput,
   type PromptSubmission,
   type InputKey
 } from "./PromptInput";
+export { getPromptCursorPlacement } from "./prompt/cursor";
 export { SessionList, formatSessionTitle } from "./SessionList";
 export { ThemedGradient } from "./ThemedGradient";
 export { UpdatePrompt, type UpdatePromptChoice } from "./UpdatePrompt";

--- a/src/ui/prompt/cursor.ts
+++ b/src/ui/prompt/cursor.ts
@@ -43,7 +43,7 @@ function disableTerminalFocusReporting(): string {
 export function getPromptCursorPlacement(
   state: PromptBufferState,
   screenWidth: number,
-  promptPrefix: string,
+  prefixWidth: number,
   footerText: string
 ): CursorPlacement {
   const width = Math.max(1, screenWidth);
@@ -53,8 +53,8 @@ export function getPromptCursorPlacement(
   const displayText = beforeCursor + (typeof at === "undefined" || at === "\n" ? " " : at) +
     (at === "\n" ? "\n" : "") + (typeof at === "undefined" ? "" : state.text.slice(cursor + 1));
 
-  const cursorPosition = measureTextPosition(beforeCursor, width, textWidth(promptPrefix));
-  const promptRows = measureTextRows(displayText, width, textWidth(promptPrefix));
+  const cursorPosition = measureTextPosition(beforeCursor, width, prefixWidth);
+  const promptRows = measureTextRows(displayText, width, prefixWidth);
   const footerRows = 1 + measureTextRows(footerText, width, 0);
 
   return {

--- a/src/ui/prompt/cursor.ts
+++ b/src/ui/prompt/cursor.ts
@@ -1,0 +1,203 @@
+import { useEffect, useLayoutEffect, useRef } from "react";
+import type { PromptBufferState } from "../promptBuffer";
+
+type CursorPlacement = {
+  rowsUp: number;
+  column: number;
+};
+
+type WriteFn = (
+  chunk: string | Uint8Array,
+  encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+  callback?: (error?: Error | null) => void
+) => boolean;
+
+function cursorUp(rows: number): string {
+  return rows > 0 ? `\u001B[${rows}A` : "";
+}
+
+function cursorDown(rows: number): string {
+  return rows > 0 ? `\u001B[${rows}B` : "";
+}
+
+function cursorForward(columns: number): string {
+  return columns > 0 ? `\u001B[${columns}C` : "";
+}
+
+function showCursor(): string {
+  return "\u001B[?25h";
+}
+
+function hideCursor(): string {
+  return "\u001B[?25l";
+}
+
+function enableTerminalFocusReporting(): string {
+  return "\u001B[?1004h";
+}
+
+function disableTerminalFocusReporting(): string {
+  return "\u001B[?1004l";
+}
+
+export function getPromptCursorPlacement(
+  state: PromptBufferState,
+  screenWidth: number,
+  promptPrefix: string,
+  footerText: string
+): CursorPlacement {
+  const width = Math.max(1, screenWidth);
+  const cursor = Math.max(0, Math.min(state.cursor, state.text.length));
+  const beforeCursor = state.text.slice(0, cursor);
+  const at = state.text[cursor];
+  const displayText = beforeCursor + (typeof at === "undefined" || at === "\n" ? " " : at) +
+    (at === "\n" ? "\n" : "") + (typeof at === "undefined" ? "" : state.text.slice(cursor + 1));
+
+  const cursorPosition = measureTextPosition(beforeCursor, width, textWidth(promptPrefix));
+  const promptRows = measureTextRows(displayText, width, textWidth(promptPrefix));
+  const footerRows = 1 + measureTextRows(footerText, width, 0);
+
+  return {
+    rowsUp: (promptRows - 1 - cursorPosition.row) + footerRows + 1,
+    column: cursorPosition.column
+  };
+}
+
+function measureTextRows(text: string, width: number, initialColumn: number): number {
+  return measureTextPosition(text, width, initialColumn).row + 1;
+}
+
+function measureTextPosition(text: string, width: number, initialColumn: number): { row: number; column: number } {
+  let row = 0;
+  let column = Math.min(initialColumn, width - 1);
+
+  for (const char of Array.from(text)) {
+    if (char === "\n") {
+      row++;
+      column = Math.min(initialColumn, width - 1);
+      continue;
+    }
+
+    const charColumns = textWidth(char);
+    if (column + charColumns > width) {
+      row++;
+      column = Math.min(initialColumn, width - 1);
+    }
+    column += charColumns;
+    if (column >= width) {
+      row++;
+      column = Math.min(initialColumn, width - 1);
+    }
+  }
+
+  return { row, column };
+}
+
+function textWidth(value: string): number {
+  let width = 0;
+  for (const char of Array.from(value.normalize())) {
+    width += characterWidth(char);
+  }
+  return width;
+}
+
+function characterWidth(char: string): number {
+  const codePoint = char.codePointAt(0) ?? 0;
+  if (codePoint === 0 || codePoint < 32 || (codePoint >= 0x7f && codePoint < 0xa0)) {
+    return 0;
+  }
+  if (codePoint >= 0x300 && codePoint <= 0x36f) {
+    return 0;
+  }
+  if (
+    (codePoint >= 0x1100 && codePoint <= 0x115f) ||
+    (codePoint >= 0x2e80 && codePoint <= 0xa4cf) ||
+    (codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
+    (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+    (codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
+    (codePoint >= 0xfe30 && codePoint <= 0xfe6f) ||
+    (codePoint >= 0xff00 && codePoint <= 0xff60) ||
+    (codePoint >= 0xffe0 && codePoint <= 0xffe6)
+  ) {
+    return 2;
+  }
+  return 1;
+}
+
+export function usePromptTerminalCursor(
+  stdout: NodeJS.WriteStream | undefined,
+  placement: CursorPlacement,
+  isActive: boolean
+): void {
+  const directWriteRef = useRef<((data: string) => void) | null>(null);
+  const activePlacementRef = useRef<CursorPlacement | null>(null);
+
+  useLayoutEffect(() => {
+    if (!stdout?.isTTY) {
+      return;
+    }
+
+    const stream = stdout as NodeJS.WriteStream & { write: WriteFn };
+    const originalWrite = stream.write;
+    const directWrite = (data: string) => {
+      originalWrite.call(stdout, data);
+    };
+    const restorePromptCursor = () => {
+      const activePlacement = activePlacementRef.current;
+      if (!activePlacement) {
+        return;
+      }
+      directWrite("\r" + cursorDown(activePlacement.rowsUp) + hideCursor());
+      activePlacementRef.current = null;
+    };
+    const patchedWrite: WriteFn = (...args) => {
+      restorePromptCursor();
+      return originalWrite.apply(stdout, args);
+    };
+
+    directWriteRef.current = directWrite;
+    stream.write = patchedWrite;
+
+    return () => {
+      restorePromptCursor();
+      stream.write = originalWrite;
+      directWriteRef.current = null;
+    };
+  }, [stdout]);
+
+  useLayoutEffect(() => {
+    if (!isActive || !stdout?.isTTY) {
+      return;
+    }
+
+    const directWrite = directWriteRef.current;
+    if (!directWrite) {
+      return;
+    }
+
+    directWrite(showCursor() + cursorUp(placement.rowsUp) + "\r" + cursorForward(placement.column));
+    activePlacementRef.current = placement;
+
+    return () => {
+      const activePlacement = activePlacementRef.current;
+      if (!activePlacement) {
+        return;
+      }
+      directWrite("\r" + cursorDown(activePlacement.rowsUp) + hideCursor());
+      activePlacementRef.current = null;
+    };
+  }, [isActive, placement.column, placement.rowsUp, stdout]);
+}
+
+export function useTerminalFocusReporting(stdout: NodeJS.WriteStream | undefined, isActive: boolean): void {
+  useLayoutEffect(() => {
+    if (!isActive || !stdout?.isTTY) {
+      return;
+    }
+
+    stdout.write(enableTerminalFocusReporting());
+    return () => {
+      stdout.write(disableTerminalFocusReporting());
+    };
+  }, [isActive, stdout]);
+}

--- a/src/ui/prompt/index.ts
+++ b/src/ui/prompt/index.ts
@@ -1,0 +1,4 @@
+export { useTerminalInput, parseTerminalInput } from "./useTerminalInput";
+export type { InputKey } from "./useTerminalInput";
+
+export { usePromptTerminalCursor, useTerminalFocusReporting, getPromptCursorPlacement } from "./cursor";

--- a/src/ui/prompt/useTerminalInput.ts
+++ b/src/ui/prompt/useTerminalInput.ts
@@ -1,0 +1,139 @@
+import { useEffect, useRef } from "react";
+import { useStdin } from "ink";
+
+export type InputKey = {
+  upArrow: boolean;
+  downArrow: boolean;
+  leftArrow: boolean;
+  rightArrow: boolean;
+  home: boolean;
+  end: boolean;
+  pageDown: boolean;
+  pageUp: boolean;
+  return: boolean;
+  escape: boolean;
+  ctrl: boolean;
+  shift: boolean;
+  tab: boolean;
+  backspace: boolean;
+  delete: boolean;
+  meta: boolean;
+  focusIn: boolean;
+  focusOut: boolean;
+};
+
+const BACKSPACE_BYTES = new Set(["\u007F", "\b"]);
+const FORWARD_DELETE_SEQUENCES = new Set(["\u001B[3~", "\u001B[P"]);
+const HOME_SEQUENCES = new Set(["\u001B[H", "\u001B[1~", "\u001B[7~", "\u001BOH"]);
+const END_SEQUENCES = new Set(["\u001B[F", "\u001B[4~", "\u001B[8~", "\u001BOF"]);
+const SHIFT_RETURN_SEQUENCES = new Set(["\u001B\r", "\u001B[13;2u"]);
+const META_RETURN_SEQUENCES = new Set(["\u001B[13;3u", "\u001B[13;4u"]);
+const CTRL_LEFT_SEQUENCES = new Set(["\u001B[1;5D", "\u001B[5D"]);
+const CTRL_RIGHT_SEQUENCES = new Set(["\u001B[1;5C", "\u001B[5C"]);
+const META_LEFT_SEQUENCES = new Set(["\u001B[1;3D", "\u001B[3D", "\u001Bb"]);
+const META_RIGHT_SEQUENCES = new Set(["\u001B[1;3C", "\u001B[3C", "\u001Bf"]);
+const TERMINAL_FOCUS_IN = "\u001B[I";
+const TERMINAL_FOCUS_OUT = "\u001B[O";
+
+export function parseTerminalInput(data: Buffer | string): { input: string; key: InputKey } {
+  const raw = String(data);
+  let input = raw;
+  const key: InputKey = {
+    upArrow: raw === "\u001B[A",
+    downArrow: raw === "\u001B[B",
+    leftArrow: raw === "\u001B[D" || CTRL_LEFT_SEQUENCES.has(raw) || META_LEFT_SEQUENCES.has(raw),
+    rightArrow: raw === "\u001B[C" || CTRL_RIGHT_SEQUENCES.has(raw) || META_RIGHT_SEQUENCES.has(raw),
+    home: HOME_SEQUENCES.has(raw),
+    end: END_SEQUENCES.has(raw),
+    pageDown: raw === "\u001B[6~",
+    pageUp: raw === "\u001B[5~",
+    return: raw === "\r" || SHIFT_RETURN_SEQUENCES.has(raw) || META_RETURN_SEQUENCES.has(raw),
+    escape: raw === "\u001B",
+    ctrl: CTRL_LEFT_SEQUENCES.has(raw) || CTRL_RIGHT_SEQUENCES.has(raw),
+    shift: SHIFT_RETURN_SEQUENCES.has(raw),
+    tab: raw === "\t" || raw === "\u001B[Z",
+    backspace: BACKSPACE_BYTES.has(raw),
+    delete: FORWARD_DELETE_SEQUENCES.has(raw),
+    meta: META_LEFT_SEQUENCES.has(raw) || META_RIGHT_SEQUENCES.has(raw) || META_RETURN_SEQUENCES.has(raw),
+    focusIn: raw === TERMINAL_FOCUS_IN,
+    focusOut: raw === TERMINAL_FOCUS_OUT
+  };
+
+  if (input <= "\u001A" && !key.return) {
+    input = String.fromCharCode(input.charCodeAt(0) + "a".charCodeAt(0) - 1);
+    key.ctrl = true;
+  }
+
+  const isKnownEscapeSequence =
+    key.upArrow ||
+    key.downArrow ||
+    key.leftArrow ||
+    key.rightArrow ||
+    key.home ||
+    key.end ||
+    key.pageDown ||
+    key.pageUp ||
+    key.tab ||
+    key.delete ||
+    key.return ||
+    key.ctrl ||
+    key.meta ||
+    key.focusIn ||
+    key.focusOut;
+
+  if (raw.startsWith("\u001B")) {
+    input = raw.slice(1);
+    key.meta = key.meta || !isKnownEscapeSequence;
+  }
+
+  const isLatinUppercase = input >= "A" && input <= "Z";
+  const isCyrillicUppercase = input >= "А" && input <= "Я";
+  if (input.length === 1 && (isLatinUppercase || isCyrillicUppercase)) {
+    key.shift = true;
+  }
+
+  if (key.tab && input === "[Z") {
+    key.shift = true;
+  }
+
+  if (key.tab || key.backspace || key.delete) {
+    input = "";
+  }
+
+  return { input, key };
+}
+
+export function useTerminalInput(
+  inputHandler: (input: string, key: InputKey) => void,
+  options: { isActive?: boolean } = {}
+): void {
+  const { stdin, setRawMode } = useStdin();
+  const isActive = options.isActive ?? true;
+  const handlerRef = useRef(inputHandler);
+  handlerRef.current = inputHandler;
+
+  useEffect(() => {
+    if (!isActive) {
+      return;
+    }
+    setRawMode(true);
+    return () => {
+      setRawMode(false);
+    };
+  }, [isActive, setRawMode]);
+
+  useEffect(() => {
+    if (!isActive) {
+      return;
+    }
+    const handleData = (data: Buffer | string) => {
+      const { input, key } = parseTerminalInput(data);
+      handlerRef.current(input, key);
+    };
+
+    stdin?.on("data", handleData);
+    return () => {
+      stdin?.off("data", handleData);
+    };
+  }, [isActive, stdin]);
+}


### PR DESCRIPTION


将现有的 PromptInput 进行内部重构（Refactor），将其拆分为：

-   useTerminalShortcuts (Hook)
-   SlashMenuView (组件)
-   PromptEditorView (组件)
  
  这样既能降低维护难度，又不会牺牲现有的高级功能。