### PR TITLE
Fix Git Bash discovery for Scoop Git on Windows

### DIFF
--- a/src/tools/shell-utils.ts
+++ b/src/tools/shell-utils.ts
@@ -26,8 +26,7 @@ export function findGitBashPath(): string {
     return cachedGitBashPath;
   }
 
-  const gitPath = findWindowsExecutable("git");
-  if (gitPath) {
+  for (const gitPath of findAllWindowsExecutableCandidates("git")) {
     const bashPath = pathWin32.join(gitPath, "..", "..", "bin", "bash.exe");
     if (fs.existsSync(bashPath)) {
       cachedGitBashPath = bashPath;
@@ -154,14 +153,8 @@ export function buildShellEnv(shellPath: string): NodeJS.ProcessEnv {
   return env;
 }
 
-function findWindowsExecutable(executable: string): string | null {
-  if (executable === "git") {
-    for (const location of WINDOWS_GIT_LOCATIONS) {
-      if (fs.existsSync(location)) {
-        return location;
-      }
-    }
-  }
+function findAllWindowsExecutableCandidates(executable: string): string[] {
+  const extraCandidates = executable === "git" ? WINDOWS_GIT_LOCATIONS : [];
 
   try {
     const output = execFileSync("where.exe", [executable], {
@@ -169,19 +162,31 @@ function findWindowsExecutable(executable: string): string | null {
       stdio: ["ignore", "pipe", "ignore"],
       windowsHide: true
     });
-    const candidates = output.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
-    const cwd = process.cwd().toLowerCase();
-    for (const candidate of candidates) {
-      const normalized = path.resolve(candidate).toLowerCase();
-      const candidateDir = path.dirname(normalized).toLowerCase();
-      if (candidateDir === cwd || normalized.startsWith(`${cwd}${path.sep}`)) {
-        continue;
-      }
-      return candidate;
-    }
+    return filterWindowsExecutableCandidates([
+      ...output.split(/\r?\n/).map((line) => line.trim()).filter(Boolean),
+      ...extraCandidates
+    ]);
   } catch {
-    // Fall through to a not-found result.
+    return filterWindowsExecutableCandidates(extraCandidates);
+  }
+}
+
+function filterWindowsExecutableCandidates(candidates: string[]): string[] {
+  const cwd = process.cwd().toLowerCase();
+  const seen = new Set<string>();
+  const results: string[] = [];
+
+  for (const candidate of candidates) {
+    const normalized = path.resolve(candidate).toLowerCase();
+    const candidateDir = path.dirname(normalized).toLowerCase();
+    if (candidateDir === cwd || normalized.startsWith(`${cwd}${path.sep}`)) {
+      continue;
+    }
+    if (!seen.has(normalized) && fs.existsSync(candidate)) {
+      seen.add(normalized);
+      results.push(candidate);
+    }
   }
 
-  return null;
+  return results;
 }


### PR DESCRIPTION
## Summary

Fix Git Bash discovery on Windows when Git is installed via Scoop.

Previously, where.exe git could return the Scoop shim before the real Git executable. The old logic only inspected the first candidate, so it derived a non-existent bash.exe path from Scoop\shims\git.exe. This change enumerates all git candidates, keeps standard Git for Windows fallback paths, de-duplicates them, and tests each derived bin\bash.exe path until one exists.

## Verification

- npm run build, using Git Bash as npm_config_script_shell on Windows
- npm run test:single src/tests/shell-utils.test.ts
- Verified findGitBashPath() resolves to D:\Program Files\Scoop\apps\git\current\bin\bash.exe on a Scoop Git installation

## Notes

Full npm test still has unrelated Windows/platform test failures in this local environment.