### PR TITLE
fix: 修复多行输入光标换行漂移

### DIFF
--- a/src/tests/promptInputKeys.test.ts
+++ b/src/tests/promptInputKeys.test.ts
@@ -117,6 +117,12 @@ test("renderBufferWithCursor draws the simulated cursor when focused", () => {
   assert.equal(stripAnsi(renderBufferWithCursor({ text: "\n", cursor: 1 }, true)), "\n ");
 });
 
+test("renderBufferWithCursor styles exactly one simulated cursor", () => {
+  assert.equal((renderBufferWithCursor({ text: "", cursor: 0 }, true).match(ANSI_RE) ?? []).length, 2);
+  assert.equal((renderBufferWithCursor({ text: "hello", cursor: 1 }, true).match(ANSI_RE) ?? []).length, 2);
+  assert.equal((renderBufferWithCursor({ text: "hello\nworld", cursor: 6 }, true).match(ANSI_RE) ?? []).length, 2);
+});
+
 test("getPromptCursorPlacement targets the prompt row above divider and footer", () => {
   const placement = getPromptCursorPlacement({ text: "hello", cursor: 5 }, 80, 2, "Enter send");
   assert.deepEqual(placement, { rowsUp: 3, column: 7 });

--- a/src/ui/PromptInput.tsx
+++ b/src/ui/PromptInput.tsx
@@ -37,7 +37,7 @@ export type { InputKey } from "./prompt";
 
 import { useTerminalInput, parseTerminalInput } from "./prompt";
 import type { InputKey } from "./prompt";
-import { usePromptTerminalCursor, useTerminalFocusReporting, getPromptCursorPlacement } from "./prompt/cursor";
+import { useHiddenTerminalCursor, useTerminalFocusReporting } from "./prompt/cursor";
 
 export type PromptSubmission = {
   text: string;
@@ -117,13 +117,8 @@ export const PromptInput = React.memo(function PromptInput({
         ? loadingText
         : "esc to interrupt · ctrl+c to cancel input"
       : "enter send · shift+enter newline · ctrl+v image · / commands · ctrl+d exit";
-  const cursorPlacement = React.useMemo(
-    () => getPromptCursorPlacement(buffer, screenWidth, PROMPT_PREFIX_WIDTH, footerText),
-    [buffer, footerText, screenWidth]
-  );
-
   useTerminalFocusReporting(stdout, !disabled);
-  usePromptTerminalCursor(stdout, cursorPlacement, !disabled);
+  useHiddenTerminalCursor(stdout, !disabled);
 
   useEffect(() => {
     if (!showMenu) {
@@ -676,7 +671,7 @@ export function renderBufferWithCursor(state: PromptBufferState, isFocused: bool
   const after = text.slice(cursor + 1);
 
   if (text.length === 0 && placeholder) {
-    return chalk.dim("  " +placeholder);
+    return chalk.dim(`  ${placeholder}`);
   }
 
   if (!isFocused) {
@@ -684,10 +679,14 @@ export function renderBufferWithCursor(state: PromptBufferState, isFocused: bool
   }
 
   if (typeof at === "undefined") {
-    return before + chalk.inverse(" ");
+    return before + renderCursorCell(" ");
   }
   if (at === "\n") {
-    return before + chalk.inverse(" ") + "\n" + after;
+    return before + renderCursorCell(" ") + "\n" + after;
   }
-  return before + chalk.inverse(at) + after;
+  return before + renderCursorCell(at) + after;
+}
+
+function renderCursorCell(value: string): string {
+  return `\u001B[7m${value}\u001B[27m`;
 }

--- a/src/ui/PromptInput.tsx
+++ b/src/ui/PromptInput.tsx
@@ -687,6 +687,8 @@ export function renderBufferWithCursor(state: PromptBufferState, isFocused: bool
   return before + renderCursorCell(at) + after;
 }
 
+// Use explicit ANSI instead of chalk.inverse so cursor rendering stays enabled
+// in non-TTY environments such as tests, where Chalk may strip styling.
 function renderCursorCell(value: string): string {
   return `\u001B[7m${value}\u001B[27m`;
 }

--- a/src/ui/prompt/cursor.ts
+++ b/src/ui/prompt/cursor.ts
@@ -211,6 +211,19 @@ export function usePromptTerminalCursor(
   }, [isActive, placement.column, placement.rowsUp, stdout]);
 }
 
+export function useHiddenTerminalCursor(stdout: NodeJS.WriteStream | undefined, isActive: boolean): void {
+  useLayoutEffect(() => {
+    if (!isActive || !stdout?.isTTY) {
+      return;
+    }
+
+    stdout.write(hideCursor());
+    return () => {
+      stdout.write(showCursor());
+    };
+  }, [isActive, stdout]);
+}
+
 export function useTerminalFocusReporting(stdout: NodeJS.WriteStream | undefined, isActive: boolean): void {
   useLayoutEffect(() => {
     if (!isActive || !stdout?.isTTY) {

--- a/src/ui/prompt/index.ts
+++ b/src/ui/prompt/index.ts
@@ -1,4 +1,4 @@
 export { useTerminalInput, parseTerminalInput } from "./useTerminalInput";
 export type { InputKey } from "./useTerminalInput";
 
-export { usePromptTerminalCursor, useTerminalFocusReporting, getPromptCursorPlacement } from "./cursor";
+export { useHiddenTerminalCursor, usePromptTerminalCursor, useTerminalFocusReporting, getPromptCursorPlacement } from "./cursor";


### PR DESCRIPTION
## 背景

<img width="851" height="431" alt="image" src="https://github.com/user-attachments/assets/1d634f53-c575-4f63-9059-09b606acd04b" />

当前 CLI 输入框在多行输入场景下存在两类光标渲染问题：

1. 输入换到第二行后，会同时出现真实终端 cursor 和文本中模拟 cursor，看起来像有两个光标。
2. 输入接近行尾自动换行时，真实终端 cursor 会和 Ink 的文本布局不同步，漂移到 `>` 所在行的行首位置。

这两个问题的根因都是输入框同时依赖真实终端 cursor 的手动定位和 Ink 文本中的 cursor 渲染，二者在多行和自动换行边界下无法稳定保持一致。

## 修改内容

- 隐藏真实终端 cursor，避免它和 Ink 渲染的输入内容不同步。
- 改为只在输入文本中渲染一个反色 cursor cell，让 cursor 跟随 Ink 的文本布局和自动换行。
- 使用显式 ANSI 反色序列渲染 cursor cell，避免 Chalk 在非 TTY 测试环境中剥离样式导致测试不稳定。
- 保留终端 focus reporting，用于失焦时隐藏模拟 cursor。
- 增加测试，确保聚焦状态下只渲染一个模拟 cursor。

## 验证

- `npm run test:single -- src/tests/promptInputKeys.test.ts`
- `npm run build`
- `npm test`
- `codex review --base origin/main` 未发现可执行回归问题
