### PR TITLE
Fix(ui): 优化/快捷命令的展示

### DIFF
--- a/src/tests/promptInputKeys.test.ts
+++ b/src/tests/promptInputKeys.test.ts
@@ -124,23 +124,23 @@ test("renderBufferWithCursor styles exactly one simulated cursor", () => {
 });
 
 test("getPromptCursorPlacement targets the prompt row above divider and footer", () => {
-  const placement = getPromptCursorPlacement({ text: "hello", cursor: 5 }, 80, 2, "Enter send");
+  const placement = getPromptCursorPlacement({ text: "hello", cursor: 5 }, 80, 2, 2);
   assert.deepEqual(placement, { rowsUp: 3, column: 7 });
 });
 
 test("getPromptCursorPlacement targets the reserved row after a trailing newline", () => {
-  const placement = getPromptCursorPlacement({ text: "hello\n", cursor: 6 }, 80, 2, "Enter send");
+  const placement = getPromptCursorPlacement({ text: "hello\n", cursor: 6 }, 80, 2, 2);
   assert.deepEqual(placement, { rowsUp: 3, column: 2 });
 });
 
 test("getPromptCursorPlacement accounts for CJK character width", () => {
-  const placement = getPromptCursorPlacement({ text: "你好", cursor: 2 }, 80, 2, "Enter send");
+  const placement = getPromptCursorPlacement({ text: "你好", cursor: 2 }, 80, 2, 2);
   assert.equal(placement.column, 6);
 });
 
 test("getPromptCursorPlacement accounts for multiline buffer rows", () => {
-  const placement = getPromptCursorPlacement({ text: "hello\nworld", cursor: 11 }, 80, 2, "Enter send");
+  const placement = getPromptCursorPlacement({ text: "hello\nworld", cursor: 11 }, 80, 2, 2);
   assert.deepEqual(placement, { rowsUp: 3, column: 7 });
-  const middle = getPromptCursorPlacement({ text: "hello\nworld", cursor: 2 }, 80, 2, "Enter send");
+  const middle = getPromptCursorPlacement({ text: "hello\nworld", cursor: 2 }, 80, 2, 2);
   assert.deepEqual(middle, { rowsUp: 4, column: 4 });
 });

--- a/src/tests/promptInputKeys.test.ts
+++ b/src/tests/promptInputKeys.test.ts
@@ -111,6 +111,7 @@ test("renderBufferWithCursor hides the simulated cursor when unfocused", () => {
 
 test("renderBufferWithCursor draws the simulated cursor when focused", () => {
   assert.equal(stripAnsi(renderBufferWithCursor({ text: "", cursor: 0 }, true)), " ");
+  assert.equal(stripAnsi(renderBufferWithCursor({ text: "", cursor: 0 }, true, "Ask anything")), "  Ask anything");
   assert.equal(stripAnsi(renderBufferWithCursor({ text: "hello", cursor: 5 }, true)), "hello ");
   assert.equal(stripAnsi(renderBufferWithCursor({ text: "hello", cursor: 1 }, true)), "hello");
   assert.equal(stripAnsi(renderBufferWithCursor({ text: "hello\n", cursor: 6 }, true)), "hello\n ");
@@ -119,28 +120,29 @@ test("renderBufferWithCursor draws the simulated cursor when focused", () => {
 
 test("renderBufferWithCursor styles exactly one simulated cursor", () => {
   assert.equal((renderBufferWithCursor({ text: "", cursor: 0 }, true).match(ANSI_RE) ?? []).length, 2);
+  assert.ok(renderBufferWithCursor({ text: "", cursor: 0 }, true, "Ask anything").includes("\u001B[7m \u001B[27m"));
   assert.equal((renderBufferWithCursor({ text: "hello", cursor: 1 }, true).match(ANSI_RE) ?? []).length, 2);
   assert.equal((renderBufferWithCursor({ text: "hello\nworld", cursor: 6 }, true).match(ANSI_RE) ?? []).length, 2);
 });
 
 test("getPromptCursorPlacement targets the prompt row above divider and footer", () => {
-  const placement = getPromptCursorPlacement({ text: "hello", cursor: 5 }, 80, 2, 2);
+  const placement = getPromptCursorPlacement({ text: "hello", cursor: 5 }, 80, 2, "Enter send");
   assert.deepEqual(placement, { rowsUp: 3, column: 7 });
 });
 
 test("getPromptCursorPlacement targets the reserved row after a trailing newline", () => {
-  const placement = getPromptCursorPlacement({ text: "hello\n", cursor: 6 }, 80, 2, 2);
+  const placement = getPromptCursorPlacement({ text: "hello\n", cursor: 6 }, 80, 2, "Enter send");
   assert.deepEqual(placement, { rowsUp: 3, column: 2 });
 });
 
 test("getPromptCursorPlacement accounts for CJK character width", () => {
-  const placement = getPromptCursorPlacement({ text: "你好", cursor: 2 }, 80, 2, 2);
+  const placement = getPromptCursorPlacement({ text: "你好", cursor: 2 }, 80, 2, "Enter send");
   assert.equal(placement.column, 6);
 });
 
 test("getPromptCursorPlacement accounts for multiline buffer rows", () => {
-  const placement = getPromptCursorPlacement({ text: "hello\nworld", cursor: 11 }, 80, 2, 2);
+  const placement = getPromptCursorPlacement({ text: "hello\nworld", cursor: 11 }, 80, 2, "Enter send");
   assert.deepEqual(placement, { rowsUp: 3, column: 7 });
-  const middle = getPromptCursorPlacement({ text: "hello\nworld", cursor: 2 }, 80, 2, 2);
+  const middle = getPromptCursorPlacement({ text: "hello\nworld", cursor: 2 }, 80, 2, "Enter send");
   assert.deepEqual(middle, { rowsUp: 4, column: 4 });
 });

--- a/src/ui/MessageView.tsx
+++ b/src/ui/MessageView.tsx
@@ -67,7 +67,7 @@ export function MessageView({ message, collapsed }: Props): React.ReactElement |
     const summary = buildToolSummary(message);
     const diffLines = getToolDiffPreviewLines(summary);
     return (
-      <Box flexDirection="column" marginBottom={1} marginY={0}>
+      <Box flexDirection="column" marginLeft={1} marginBottom={1} marginY={0}>
         <StatusLine
           bulletColor={summary.ok ? "green" : "red"}
           name={formatStatusName(summary.name)}
@@ -81,14 +81,14 @@ export function MessageView({ message, collapsed }: Props): React.ReactElement |
   if (message.role === "system") {
     if (message.meta?.skill) {
       return (
-        <Box marginY={0} marginBottom={1}>
+        <Box marginY={0} marginLeft={1} marginBottom={1}>
           <Text color="magenta">⚡ Loaded skill: {message.meta.skill.name}</Text>
         </Box>
       );
     }
     if (message.meta?.isSummary) {
       return (
-        <Box marginY={0} marginBottom={1}>
+        <Box marginY={0} marginLeft={1} marginBottom={1}>
           <Text dimColor italic>(conversation summary inserted)</Text>
         </Box>
       );

--- a/src/ui/MessageView.tsx
+++ b/src/ui/MessageView.tsx
@@ -38,13 +38,13 @@ export function MessageView({ message, collapsed }: Props): React.ReactElement |
       const summary = buildThinkingSummary(content, message.messageParams);
       if (collapsed !== false) {
         return (
-          <Box marginY={0}>
+          <Box marginLeft={1} marginY={0}>
             <StatusLine bulletColor="gray" name="Thinking" params={summary} />
           </Box>
         );
       }
       return (
-        <Box  marginLeft={1} flexDirection="column" marginY={0}>
+        <Box marginLeft={1} flexDirection="column" marginY={0}>
           <StatusLine bulletColor="gray" name="Thinking" params={summary} />
           <Box flexDirection="column">
             {content ? <Text dimColor>{renderMarkdown(content)}</Text> : null}

--- a/src/ui/MessageView.tsx
+++ b/src/ui/MessageView.tsx
@@ -111,7 +111,7 @@ function StatusLine({
   return (
     <Text wrap="truncate-end">
       {[
-        <Text key="bullet" color={bulletColor}>•</Text>,
+        <Text key="bullet" color={bulletColor}>✧</Text>,
         " ",
         <Text key="name" bold>{name}</Text>,
         params ? <Text key="params" color="white">{`  ${params}`}</Text> : null

--- a/src/ui/PromptInput.tsx
+++ b/src/ui/PromptInput.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useMemo, useState} from "react";
+import React, {useEffect, useState} from "react";
 import { Box, Text, useApp, useStdout } from "ink";
 import chalk from "chalk";
 import {
@@ -33,8 +33,9 @@ import type { SkillInfo } from "../session";
 export { useTerminalInput, parseTerminalInput } from "./prompt";
 export type { InputKey } from "./prompt";
 
+import { useTerminalInput, parseTerminalInput } from "./prompt";
 import type { InputKey } from "./prompt";
-import { useTerminalInput, usePromptTerminalCursor, useTerminalFocusReporting, getPromptCursorPlacement, measureTextRows } from "./prompt";
+import { useHiddenTerminalCursor, useTerminalFocusReporting } from "./prompt";
 import SlashCommandMenu from "./SlashCommandMenu";
 
 export type PromptSubmission = {
@@ -57,7 +58,6 @@ type Props = {
 };
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
-const PROMPT_PREFIX_WIDTH = 2;
 
 const PromptPrefixLine = React.memo(function PromptPrefixLine({ busy }: { busy: boolean }): React.ReactElement {
   const [spinnerIndex, setSpinnerIndex] = useState(0);
@@ -74,20 +74,20 @@ const PromptPrefixLine = React.memo(function PromptPrefixLine({ busy }: { busy: 
   }, [busy]);
 
   const prefix = busy ? `${SPINNER_FRAMES[spinnerIndex]} ` : "> ";
-  return <Text color={busy ? "yellow" : "#229ac3"}>{prefix}</Text>;
+  return <Text color={busy ? "yellow" : "green"}>{prefix}</Text>;
 });
 
 export const PromptInput = React.memo(function PromptInput({
-  skills,
-  screenWidth,
-  promptHistory,
-  busy,
-  loadingText,
-  disabled,
-  placeholder,
-  onSubmit,
-  onInterrupt
-}: Props): React.ReactElement {
+                                                             skills,
+                                                             screenWidth,
+                                                             promptHistory,
+                                                             busy,
+                                                             loadingText,
+                                                             disabled,
+                                                             placeholder,
+                                                             onSubmit,
+                                                             onInterrupt
+                                                           }: Props): React.ReactElement {
   const { exit } = useApp();
   const { stdout } = useStdout();
   const [buffer, setBuffer] = useState<PromptBufferState>(EMPTY_BUFFER);
@@ -115,33 +115,8 @@ export const PromptInput = React.memo(function PromptInput({
         ? loadingText
         : "esc to interrupt · ctrl+c to cancel input"
       : "enter send · shift+enter newline · ctrl+v image · / commands · ctrl+d exit";
-
-  // Compute where the terminal hardware cursor should be placed.
-  // The terminal cursor is the ONLY cursor — BufferWithCursor renders
-  // plain text without any inverse styling, relying on the terminal's
-  // native blinking cursor for visual feedback.
-  const cursorPlacement = React.useMemo(() => {
-    const menuRows = showMenu
-      ? (() => {
-          const maxVisible = 6;
-          const visibleStart = Math.min(
-            Math.max(0, menuIndex - Math.floor((maxVisible - 1) / 2)),
-            Math.max(0, slashMenu.length - maxVisible)
-          );
-          const visibleCount = Math.min(slashMenu.length, maxVisible);
-          const hasTopArrow = visibleStart > 0 ? 1 : 0;
-          const hasBottomArrow = visibleStart + visibleCount < slashMenu.length ? 1 : 0;
-          return hasTopArrow + visibleCount + hasBottomArrow + 1 + 1;
-        })()
-      : 0;
-    const belowRows = showMenu
-      ? 1 + menuRows
-      : 1 + measureTextRows(footerText, screenWidth, 0);
-    return getPromptCursorPlacement(buffer, screenWidth, PROMPT_PREFIX_WIDTH, belowRows);
-  }, [buffer, footerText, screenWidth, showMenu, slashMenu.length, menuIndex]);
-
   useTerminalFocusReporting(stdout, !disabled);
-  usePromptTerminalCursor(stdout, cursorPlacement, !disabled);
+  useHiddenTerminalCursor(stdout, !disabled);
 
   useEffect(() => {
     if (!showMenu) {
@@ -434,9 +409,7 @@ export const PromptInput = React.memo(function PromptInput({
     }
 
     if (input && !key.ctrl && !key.meta) {
-      // Normalize line endings from paste: \r\n (Windows) → \n, \r (old macOS/Enter) → \n.
-      // This preserves multi-line formatting when the user pastes content.
-      const sanitized = input.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+      const sanitized = input.replace(/\r/g, "");
       updateBuffer((s) => insertText(s, sanitized));
     }
   }, { isActive: !disabled });
@@ -473,7 +446,7 @@ export const PromptInput = React.memo(function PromptInput({
     }
 
     const text = promptHistory[nextCursor] ?? "";
-    setBuffer({ text, cursor: direction < 0 ? 0 : text.length });
+    setBuffer({ text, cursor: text.length });
     setHistoryCursor(nextCursor);
   }
 
@@ -588,7 +561,7 @@ export const PromptInput = React.memo(function PromptInput({
            borderRight={false}
            borderDimColor>
         <PromptPrefixLine busy={busy} />
-        <BufferWithCursor state={buffer} isFocused={!disabled && hasTerminalFocus} placeholder={placeholder} />
+        <Text>{renderBufferWithCursor(buffer, !disabled && hasTerminalFocus, placeholder)}</Text>
       </Box>
       {showSkillsDropdown ? (
         <Box flexDirection="column" marginBottom={1}>
@@ -679,40 +652,6 @@ export function isClearImageAttachmentsShortcut(input: string, key: Pick<InputKe
   return key.ctrl && (input === "x" || input === "X");
 }
 
-/**
- * JSX component that renders the input buffer as plain text.
- * No inverse styling is applied — the terminal hardware cursor
- * (positioned by usePromptTerminalCursor) provides the only
- * cursor visual, giving the user a native blinking cursor.
- *
- * The key={state.cursor} forces a full re-render on cursor movement,
- * which prevents Ink from leaving stale characters in the terminal.
- */
-function BufferWithCursor({ state, isFocused, placeholder }: {
-  state: PromptBufferState;
-  isFocused: boolean;
-  placeholder?: string;
-}): React.ReactElement {
-  const text = state.text || "";
-
-  if (text.length === 0 && placeholder) {
-    return <Text key={state.cursor} dimColor>{`  ${placeholder}`}</Text>;
-  }
-
-  if (!isFocused) {
-    return <Text key={state.cursor}>{text.endsWith("\n") ? `${text} ` : text}</Text>;
-  }
-
-  // Render plain text only.  The terminal hardware cursor provides the
-  // blinking indicator at the correct position.
-  return <Text key={state.cursor}>{text}</Text>;
-}
-
-/**
- * Render the input buffer as a plain string with an ANSI inverse cell at the
- * cursor position.  Kept for external use (e.g. tests) where Ink JSX is not
- * available.  Prefer BufferWithCursor inside Ink render trees.
- */
 export function renderBufferWithCursor(state: PromptBufferState, isFocused: boolean, placeholder?: string): string {
   const text = state.text || "";
   const cursor = Math.max(0, Math.min(state.cursor, text.length));
@@ -721,7 +660,10 @@ export function renderBufferWithCursor(state: PromptBufferState, isFocused: bool
   const after = text.slice(cursor + 1);
 
   if (text.length === 0 && placeholder) {
-    return chalk.dim(`  ${placeholder}`);
+    if (!isFocused) {
+      return chalk.dim(`  ${placeholder}`);
+    }
+    return renderCursorCell(" ") + chalk.dim(` ${placeholder}`);
   }
 
   if (!isFocused) {
@@ -737,11 +679,8 @@ export function renderBufferWithCursor(state: PromptBufferState, isFocused: bool
   return before + renderCursorCell(at) + after;
 }
 
-/**
- * Wrap a character with ANSI inverse codes (CSI 7 m ... CSI 27 m).
- * Explicit ANSI is used instead of chalk.inverse so the cursor stays visible
- * in non-TTY environments (e.g. tests) where Chalk strips styling.
- */
+// Use explicit ANSI instead of chalk.inverse so cursor rendering stays enabled
+// in non-TTY environments such as tests, where Chalk may strip styling.
 function renderCursorCell(value: string): string {
   return `\u001B[7m${value}\u001B[27m`;
 }

--- a/src/ui/PromptInput.tsx
+++ b/src/ui/PromptInput.tsx
@@ -74,7 +74,7 @@ const PromptPrefixLine = React.memo(function PromptPrefixLine({ busy }: { busy: 
   }, [busy]);
 
   const prefix = busy ? `${SPINNER_FRAMES[spinnerIndex]} ` : "> ";
-  return <Text color={busy ? "yellow" : "green"}>{prefix}</Text>;
+  return <Text color={busy ? "yellow" : "#229ac3"}>{prefix}</Text>;
 });
 
 export const PromptInput = React.memo(function PromptInput({
@@ -590,9 +590,9 @@ export const PromptInput = React.memo(function PromptInput({
         </Box>
       ) : null}
       <SlashCommandMenu width={screenWidth} items={slashMenu} activeIndex={menuIndex} />
-      <Box>
+      {!showMenu && <Box>
         <Text dimColor>{footerText}</Text>
-      </Box>
+      </Box>}
     </Box>
   );
 });

--- a/src/ui/PromptInput.tsx
+++ b/src/ui/PromptInput.tsx
@@ -34,7 +34,7 @@ export { useTerminalInput, parseTerminalInput } from "./prompt";
 export type { InputKey } from "./prompt";
 
 import type { InputKey } from "./prompt";
-import { useHiddenTerminalCursor, useTerminalFocusReporting } from "./prompt/cursor";
+import { useTerminalInput, useHiddenTerminalCursor, useTerminalFocusReporting } from "./prompt/cursor";
 import SlashCommandMenu from "./SlashCommandMenu";
 
 export type PromptSubmission = {
@@ -533,7 +533,6 @@ export const PromptInput = React.memo(function PromptInput({
     setBuffer((state) => removeCurrentSlashToken(state));
   }
 
-  const divider = useMemo(() => "─".repeat(screenWidth), [screenWidth]);
   const visibleSkillStart = Math.min(
     Math.max(0, skillsDropdownIndex - 7),
     Math.max(0, skills.length - 8)
@@ -555,12 +554,15 @@ export const PromptInput = React.memo(function PromptInput({
         </Box>
       ) : null}
       {/* Input */}
-      <Text dimColor wrap="truncate-end">{divider}</Text>
-      <Box>
+      <Box borderStyle="single"
+           borderTop={true}
+           borderBottom={true}
+           borderLeft={false}
+           borderRight={false}
+           borderDimColor>
         <PromptPrefixLine busy={busy} />
         <Text>{renderBufferWithCursor(buffer, !disabled && hasTerminalFocus, placeholder)}</Text>
       </Box>
-      <Text dimColor wrap="truncate-end">{divider}</Text>
       {showSkillsDropdown ? (
         <Box flexDirection="column" marginBottom={1}>
           <Text color="magenta" bold>Select Skills</Text>
@@ -648,6 +650,26 @@ export function removeCurrentSlashToken(state: PromptBufferState): PromptBufferS
 
 export function isClearImageAttachmentsShortcut(input: string, key: Pick<InputKey, "ctrl">): boolean {
   return key.ctrl && (input === "x" || input === "X");
+}
+
+function BufferWithCursor({ state, isFocused, placeholder }: {
+  state: PromptBufferState;
+  isFocused: boolean;
+  placeholder?: string;
+}): React.ReactElement {
+  const text = state.text || "";
+
+  if (text.length === 0 && placeholder) {
+    return <Text key={state.cursor} dimColor>{`  ${placeholder}`}</Text>;
+  }
+
+  if (!isFocused) {
+    return <Text key={state.cursor}>{text.endsWith("\n") ? `${text} ` : text}</Text>;
+  }
+
+  // Render text normally. The terminal hardware cursor (positioned by
+  // usePromptTerminalCursor) provides the blinking cursor feedback.
+  return <Text key={state.cursor}>{text}</Text>;
 }
 
 export function renderBufferWithCursor(state: PromptBufferState, isFocused: boolean, placeholder?: string): string {

--- a/src/ui/PromptInput.tsx
+++ b/src/ui/PromptInput.tsx
@@ -434,7 +434,9 @@ export const PromptInput = React.memo(function PromptInput({
     }
 
     if (input && !key.ctrl && !key.meta) {
-      const sanitized = input.replace(/\r/g, "");
+      // Normalize line endings from paste: \r\n (Windows) → \n, \r (old macOS/Enter) → \n.
+      // This preserves multi-line formatting when the user pastes content.
+      const sanitized = input.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
       updateBuffer((s) => insertText(s, sanitized));
     }
   }, { isActive: !disabled });

--- a/src/ui/PromptInput.tsx
+++ b/src/ui/PromptInput.tsx
@@ -25,8 +25,6 @@ import {
   buildSlashCommands,
   filterSlashCommands,
   findExactSlashCommand,
-  formatSlashCommandDescription,
-  formatSlashCommandLabel
 } from "./slashCommands";
 import { readClipboardImageAsync } from "./clipboard";
 import type { SkillInfo } from "../session";
@@ -35,9 +33,9 @@ import type { SkillInfo } from "../session";
 export { useTerminalInput, parseTerminalInput } from "./prompt";
 export type { InputKey } from "./prompt";
 
-import { useTerminalInput, parseTerminalInput } from "./prompt";
 import type { InputKey } from "./prompt";
 import { useHiddenTerminalCursor, useTerminalFocusReporting } from "./prompt/cursor";
+import SlashCommandMenu from "./SlashCommandMenu";
 
 export type PromptSubmission = {
   text: string;
@@ -556,6 +554,13 @@ export const PromptInput = React.memo(function PromptInput({
           <Text dimColor> (use /skills to edit)</Text>
         </Box>
       ) : null}
+      {/* Input */}
+      <Text dimColor wrap="truncate-end">{divider}</Text>
+      <Box>
+        <PromptPrefixLine busy={busy} />
+        <Text>{renderBufferWithCursor(buffer, !disabled && hasTerminalFocus, placeholder)}</Text>
+      </Box>
+      <Text dimColor wrap="truncate-end">{divider}</Text>
       {showSkillsDropdown ? (
         <Box flexDirection="column" marginBottom={1}>
           <Text color="magenta" bold>Select Skills</Text>
@@ -581,28 +586,10 @@ export const PromptInput = React.memo(function PromptInput({
           {visibleSkillStart + visibleSkills.length < skills.length ? (
             <Text dimColor>… {skills.length - visibleSkillStart - visibleSkills.length} more</Text>
           ) : null}
-          <Text dimColor>space toggle · enter toggle · esc close</Text>
+          <Text dimColor>space toggle · enter toggle · esc to close</Text>
         </Box>
       ) : null}
-      {showMenu ? (
-        <Box flexDirection="column" marginBottom={1}>
-          {slashMenu.slice(0, 8).map((item, idx) => (
-            <Text key={item.label} color={idx === menuIndex ? "cyanBright" : undefined} wrap="truncate-end">
-              {idx === menuIndex ? "› " : "  "}
-              <Text bold>{formatSlashCommandLabel(item)}</Text>
-              <Text dimColor>  {formatSlashCommandDescription(item.description)}</Text>
-            </Text>
-          ))}
-          {slashMenu.length > 8 ? <Text dimColor>… {slashMenu.length - 8} more</Text> : null}
-        </Box>
-      ) : null}
-      {/* Input */}
-      <Text dimColor wrap="truncate-end">{divider}</Text>
-      <Box>
-        <PromptPrefixLine busy={busy} />
-        <Text>{renderBufferWithCursor(buffer, !disabled && hasTerminalFocus, placeholder)}</Text>
-      </Box>
-      <Text dimColor wrap="truncate-end">{divider}</Text>
+      <SlashCommandMenu width={screenWidth} items={slashMenu} activeIndex={menuIndex} />
       <Box>
         <Text dimColor>{footerText}</Text>
       </Box>

--- a/src/ui/PromptInput.tsx
+++ b/src/ui/PromptInput.tsx
@@ -34,7 +34,7 @@ export { useTerminalInput, parseTerminalInput } from "./prompt";
 export type { InputKey } from "./prompt";
 
 import type { InputKey } from "./prompt";
-import { useTerminalInput, useHiddenTerminalCursor, useTerminalFocusReporting } from "./prompt/cursor";
+import { useTerminalInput, usePromptTerminalCursor, useTerminalFocusReporting, getPromptCursorPlacement, measureTextRows } from "./prompt";
 import SlashCommandMenu from "./SlashCommandMenu";
 
 export type PromptSubmission = {
@@ -115,8 +115,33 @@ export const PromptInput = React.memo(function PromptInput({
         ? loadingText
         : "esc to interrupt · ctrl+c to cancel input"
       : "enter send · shift+enter newline · ctrl+v image · / commands · ctrl+d exit";
+
+  // Compute where the terminal hardware cursor should be placed.
+  // The terminal cursor is the ONLY cursor — BufferWithCursor renders
+  // plain text without any inverse styling, relying on the terminal's
+  // native blinking cursor for visual feedback.
+  const cursorPlacement = React.useMemo(() => {
+    const menuRows = showMenu
+      ? (() => {
+          const maxVisible = 6;
+          const visibleStart = Math.min(
+            Math.max(0, menuIndex - Math.floor((maxVisible - 1) / 2)),
+            Math.max(0, slashMenu.length - maxVisible)
+          );
+          const visibleCount = Math.min(slashMenu.length, maxVisible);
+          const hasTopArrow = visibleStart > 0 ? 1 : 0;
+          const hasBottomArrow = visibleStart + visibleCount < slashMenu.length ? 1 : 0;
+          return hasTopArrow + visibleCount + hasBottomArrow + 1 + 1;
+        })()
+      : 0;
+    const belowRows = showMenu
+      ? 1 + menuRows
+      : 1 + measureTextRows(footerText, screenWidth, 0);
+    return getPromptCursorPlacement(buffer, screenWidth, PROMPT_PREFIX_WIDTH, belowRows);
+  }, [buffer, footerText, screenWidth, showMenu, slashMenu.length, menuIndex]);
+
   useTerminalFocusReporting(stdout, !disabled);
-  useHiddenTerminalCursor(stdout, !disabled);
+  usePromptTerminalCursor(stdout, cursorPlacement, !disabled);
 
   useEffect(() => {
     if (!showMenu) {
@@ -561,7 +586,7 @@ export const PromptInput = React.memo(function PromptInput({
            borderRight={false}
            borderDimColor>
         <PromptPrefixLine busy={busy} />
-        <Text>{renderBufferWithCursor(buffer, !disabled && hasTerminalFocus, placeholder)}</Text>
+        <BufferWithCursor state={buffer} isFocused={!disabled && hasTerminalFocus} placeholder={placeholder} />
       </Box>
       {showSkillsDropdown ? (
         <Box flexDirection="column" marginBottom={1}>
@@ -652,6 +677,15 @@ export function isClearImageAttachmentsShortcut(input: string, key: Pick<InputKe
   return key.ctrl && (input === "x" || input === "X");
 }
 
+/**
+ * JSX component that renders the input buffer as plain text.
+ * No inverse styling is applied — the terminal hardware cursor
+ * (positioned by usePromptTerminalCursor) provides the only
+ * cursor visual, giving the user a native blinking cursor.
+ *
+ * The key={state.cursor} forces a full re-render on cursor movement,
+ * which prevents Ink from leaving stale characters in the terminal.
+ */
 function BufferWithCursor({ state, isFocused, placeholder }: {
   state: PromptBufferState;
   isFocused: boolean;
@@ -667,11 +701,16 @@ function BufferWithCursor({ state, isFocused, placeholder }: {
     return <Text key={state.cursor}>{text.endsWith("\n") ? `${text} ` : text}</Text>;
   }
 
-  // Render text normally. The terminal hardware cursor (positioned by
-  // usePromptTerminalCursor) provides the blinking cursor feedback.
+  // Render plain text only.  The terminal hardware cursor provides the
+  // blinking indicator at the correct position.
   return <Text key={state.cursor}>{text}</Text>;
 }
 
+/**
+ * Render the input buffer as a plain string with an ANSI inverse cell at the
+ * cursor position.  Kept for external use (e.g. tests) where Ink JSX is not
+ * available.  Prefer BufferWithCursor inside Ink render trees.
+ */
 export function renderBufferWithCursor(state: PromptBufferState, isFocused: boolean, placeholder?: string): string {
   const text = state.text || "";
   const cursor = Math.max(0, Math.min(state.cursor, text.length));
@@ -696,8 +735,11 @@ export function renderBufferWithCursor(state: PromptBufferState, isFocused: bool
   return before + renderCursorCell(at) + after;
 }
 
-// Use explicit ANSI instead of chalk.inverse so cursor rendering stays enabled
-// in non-TTY environments such as tests, where Chalk may strip styling.
+/**
+ * Wrap a character with ANSI inverse codes (CSI 7 m ... CSI 27 m).
+ * Explicit ANSI is used instead of chalk.inverse so the cursor stays visible
+ * in non-TTY environments (e.g. tests) where Chalk strips styling.
+ */
 function renderCursorCell(value: string): string {
   return `\u001B[7m${value}\u001B[27m`;
 }

--- a/src/ui/SlashCommandMenu.tsx
+++ b/src/ui/SlashCommandMenu.tsx
@@ -50,9 +50,7 @@ const SlashCommandMenu = React.memo(function SlashCommandMenu({
               </Text>
             </Box>
             <Box flexGrow={1}>
-              <Text color={actualIndex === activeIndex ? "#229ac3" : undefined} wrap="truncate-end">
-                <Text dimColor>{formatSlashCommandDescription(item.description)}</Text>
-              </Text>
+              <Text color={actualIndex === activeIndex ? "#229ac3" : undefined} wrap="truncate-end" dimColor>{formatSlashCommandDescription(item.description)}</Text>
             </Box>
           </Box>
         );

--- a/src/ui/SlashCommandMenu.tsx
+++ b/src/ui/SlashCommandMenu.tsx
@@ -1,0 +1,70 @@
+import {formatSlashCommandDescription, formatSlashCommandLabel, SlashCommandItem} from "./slashCommands";
+import React from "react";
+import {Box, Text} from "ink";
+
+type SlashCommandMenuProps = {
+  items: SlashCommandItem[];
+  activeIndex: number;
+  width: number;
+  maxVisible?: number;
+};
+
+const SlashCommandMenu = React.memo(function SlashCommandMenu({
+                                                                items,
+                                                                activeIndex,
+                                                                maxVisible = 6,
+                                                                width
+                                                              }: SlashCommandMenuProps): React.ReactElement | null {
+  if (items.length === 0) {
+    return null;
+  }
+
+  // 计算可见窗口起始位置，确保 activeIndex 始终在可见区域内
+  const visibleStart = Math.min(
+    Math.max(0, activeIndex - Math.floor((maxVisible - 1) / 2)),
+    Math.max(0, items.length - maxVisible)
+  );
+  const visibleItems = items.slice(visibleStart, visibleStart + maxVisible);
+
+  // 计算标签列最佳宽度：包含前缀"› "或"  "（2字符），不超过容器一半（扣除gap）
+  const labelColumnWidth = React.useMemo(() => {
+    const longestLabel = Math.max(...items.map((s) => s.label.length));
+    const contentWidth = longestLabel + 2; // +2 for prefix "› " or "  "
+    const maxAllowed = Math.max(10, (width - 2) >> 1); // 容器50%宽度（减去gap），至少保留10列
+    return Math.min(contentWidth, maxAllowed);
+  }, [items, width]);
+
+  return (
+    <Box flexDirection="column" marginBottom={1} width={width}>
+      {visibleStart > 0 ? (
+        <Box marginLeft={2}><Text dimColor>▲</Text></Box>
+      ) : null}
+      {visibleItems.map((item, idx) => {
+        const actualIndex = visibleStart + idx;
+        return (
+          <Box key={item.label} gap={2} flexDirection="row" flexGrow={1}>
+            <Box width={labelColumnWidth} flexShrink={0}>
+              <Text color={actualIndex === activeIndex ? "cyanBright" : undefined} wrap="truncate-end">
+                {actualIndex === activeIndex ? "› " : "  "}
+                <Text bold>{formatSlashCommandLabel(item)}</Text>
+              </Text>
+            </Box>
+            <Box flexGrow={1}>
+              <Text color={actualIndex === activeIndex ? "cyanBright" : undefined} wrap="truncate-end">
+                <Text dimColor>{formatSlashCommandDescription(item.description)}</Text>
+              </Text>
+            </Box>
+          </Box>
+        );
+      })}
+      <Box marginLeft={2} flexDirection='column'>
+        {visibleStart + visibleItems.length < items.length ? (
+          <Text dimColor>▼</Text>
+        ) : null}
+        <Text dimColor>({activeIndex + 1}/{items.length})  ↑↓ to navigate · Enter to select</Text>
+      </Box>
+    </Box>
+  );
+});
+
+export default SlashCommandMenu;

--- a/src/ui/SlashCommandMenu.tsx
+++ b/src/ui/SlashCommandMenu.tsx
@@ -44,13 +44,13 @@ const SlashCommandMenu = React.memo(function SlashCommandMenu({
         return (
           <Box key={item.label} gap={2} flexDirection="row" flexGrow={1}>
             <Box width={labelColumnWidth} flexShrink={0}>
-              <Text color={actualIndex === activeIndex ? "cyanBright" : undefined} wrap="truncate-end">
+              <Text color={actualIndex === activeIndex ? "#229ac3" : undefined} wrap="truncate-end">
                 {actualIndex === activeIndex ? "› " : "  "}
                 <Text bold>{formatSlashCommandLabel(item)}</Text>
               </Text>
             </Box>
             <Box flexGrow={1}>
-              <Text color={actualIndex === activeIndex ? "cyanBright" : undefined} wrap="truncate-end">
+              <Text color={actualIndex === activeIndex ? "#229ac3" : undefined} wrap="truncate-end">
                 <Text dimColor>{formatSlashCommandDescription(item.description)}</Text>
               </Text>
             </Box>

--- a/src/ui/prompt/cursor.ts
+++ b/src/ui/prompt/cursor.ts
@@ -40,17 +40,11 @@ function disableTerminalFocusReporting(): string {
   return "\u001B[?1004l";
 }
 
-/**
- * Calculate where the terminal hardware cursor should be placed relative to
- * the Ink-rendered inverse cursor cell.  The returned {@code rowsUp} and
- * {@code column} values are used by {@link usePromptTerminalCursor} to
- * position the terminal's blinking cursor on top of the simulated inverse cell.
- */
 export function getPromptCursorPlacement(
   state: PromptBufferState,
   screenWidth: number,
   prefixWidth: number,
-  belowRows: number
+  footerText: string
 ): CursorPlacement {
   const width = Math.max(1, screenWidth);
   const cursor = Math.max(0, Math.min(state.cursor, state.text.length));
@@ -61,14 +55,15 @@ export function getPromptCursorPlacement(
 
   const cursorPosition = measureTextPosition(beforeCursor, width, prefixWidth);
   const promptRows = measureTextRows(displayText, width, prefixWidth);
+  const footerRows = 1 + measureTextRows(footerText, width, 0);
 
   return {
-    rowsUp: (promptRows - 1 - cursorPosition.row) + belowRows + 1,
+    rowsUp: (promptRows - 1 - cursorPosition.row) + footerRows + 1,
     column: cursorPosition.column
   };
 }
 
-export function measureTextRows(text: string, width: number, initialColumn: number): number {
+function measureTextRows(text: string, width: number, initialColumn: number): number {
   return measureTextPosition(text, width, initialColumn).row + 1;
 }
 
@@ -136,12 +131,11 @@ export function usePromptTerminalCursor(
 ): void {
   const directWriteRef = useRef<((data: string) => void) | null>(null);
   const activePlacementRef = useRef<CursorPlacement | null>(null);
+  const lastPlacementRef = useRef<CursorPlacement | null>(null);
   const unmountingRef = useRef(false);
 
-  // Patch stdout.write to hide the cursor before every write. This prevents
-  // the terminal cursor from appearing mid-render at the wrong position.
   useLayoutEffect(() => {
-    if (!isActive || !stdout?.isTTY) {
+    if (!stdout?.isTTY) {
       return;
     }
 
@@ -150,27 +144,45 @@ export function usePromptTerminalCursor(
     const directWrite = (data: string) => {
       originalWrite.call(stdout, data);
     };
-
-    directWriteRef.current = directWrite;
-
-    const patchedWrite: WriteFn = (...args) => {
-      // Before each write, move the cursor back to the bottom and hide it.
-      if (!unmountingRef.current && activePlacementRef.current) {
-        directWrite("\r" + cursorDown(activePlacementRef.current.rowsUp) + hideCursor());
-        activePlacementRef.current = null;
+    const restorePromptCursor = () => {
+      if (unmountingRef.current) {
+        return;
       }
+      const activePlacement = activePlacementRef.current;
+      if (!activePlacement) {
+        return;
+      }
+      directWrite("\r" + cursorDown(activePlacement.rowsUp) + hideCursor());
+      activePlacementRef.current = null;
+      // Schedule a deferred re-position in case the layout effect does not
+      // re-run (e.g. a dropdown closed without changing the buffer).
+      Promise.resolve().then(() => {
+        if (unmountingRef.current || activePlacementRef.current) {
+          return;
+        }
+        const latest = directWriteRef.current;
+        const p = lastPlacementRef.current;
+        if (latest && p) {
+          latest(showCursor() + cursorUp(p.rowsUp) + "\r" + cursorForward(p.column));
+          activePlacementRef.current = p;
+        }
+      });
+    };
+    const patchedWrite: WriteFn = (...args) => {
+      restorePromptCursor();
       return originalWrite.apply(stdout, args);
     };
 
+    directWriteRef.current = directWrite;
     stream.write = patchedWrite;
+
     return () => {
-      unmountingRef.current = true;
+      restorePromptCursor();
       stream.write = originalWrite;
       directWriteRef.current = null;
     };
-  }, [isActive, stdout]);
+  }, [stdout]);
 
-  // Show and position the terminal cursor after each render.
   useLayoutEffect(() => {
     if (!isActive || !stdout?.isTTY) {
       return;
@@ -184,17 +196,32 @@ export function usePromptTerminalCursor(
 
     directWrite(showCursor() + cursorUp(placement.rowsUp) + "\r" + cursorForward(placement.column));
     activePlacementRef.current = placement;
+    lastPlacementRef.current = placement;
 
     return () => {
       unmountingRef.current = true;
-      const p = activePlacementRef.current;
-      if (!p) {
+      lastPlacementRef.current = null;
+      const activePlacement = activePlacementRef.current;
+      if (!activePlacement) {
         return;
       }
-      directWrite("\r" + cursorDown(p.rowsUp) + hideCursor());
+      directWrite("\r" + cursorDown(activePlacement.rowsUp) + hideCursor());
       activePlacementRef.current = null;
     };
-  }, [isActive, placement.rowsUp, placement.column, stdout]);
+  }, [isActive, placement.column, placement.rowsUp, stdout]);
+}
+
+export function useHiddenTerminalCursor(stdout: NodeJS.WriteStream | undefined, isActive: boolean): void {
+  useLayoutEffect(() => {
+    if (!isActive || !stdout?.isTTY) {
+      return;
+    }
+
+    stdout.write(hideCursor());
+    return () => {
+      stdout.write(showCursor());
+    };
+  }, [isActive, stdout]);
 }
 
 export function useTerminalFocusReporting(stdout: NodeJS.WriteStream | undefined, isActive: boolean): void {

--- a/src/ui/prompt/cursor.ts
+++ b/src/ui/prompt/cursor.ts
@@ -44,7 +44,7 @@ export function getPromptCursorPlacement(
   state: PromptBufferState,
   screenWidth: number,
   prefixWidth: number,
-  footerText: string
+  belowRows: number
 ): CursorPlacement {
   const width = Math.max(1, screenWidth);
   const cursor = Math.max(0, Math.min(state.cursor, state.text.length));
@@ -55,15 +55,14 @@ export function getPromptCursorPlacement(
 
   const cursorPosition = measureTextPosition(beforeCursor, width, prefixWidth);
   const promptRows = measureTextRows(displayText, width, prefixWidth);
-  const footerRows = 1 + measureTextRows(footerText, width, 0);
 
   return {
-    rowsUp: (promptRows - 1 - cursorPosition.row) + footerRows + 1,
+    rowsUp: (promptRows - 1 - cursorPosition.row) + belowRows + 1,
     column: cursorPosition.column
   };
 }
 
-function measureTextRows(text: string, width: number, initialColumn: number): number {
+export function measureTextRows(text: string, width: number, initialColumn: number): number {
   return measureTextPosition(text, width, initialColumn).row + 1;
 }
 
@@ -131,11 +130,12 @@ export function usePromptTerminalCursor(
 ): void {
   const directWriteRef = useRef<((data: string) => void) | null>(null);
   const activePlacementRef = useRef<CursorPlacement | null>(null);
-  const lastPlacementRef = useRef<CursorPlacement | null>(null);
   const unmountingRef = useRef(false);
 
+  // Patch stdout.write to hide the cursor before every write. This prevents
+  // the terminal cursor from appearing mid-render at the wrong position.
   useLayoutEffect(() => {
-    if (!stdout?.isTTY) {
+    if (!isActive || !stdout?.isTTY) {
       return;
     }
 
@@ -144,45 +144,27 @@ export function usePromptTerminalCursor(
     const directWrite = (data: string) => {
       originalWrite.call(stdout, data);
     };
-    const restorePromptCursor = () => {
-      if (unmountingRef.current) {
-        return;
-      }
-      const activePlacement = activePlacementRef.current;
-      if (!activePlacement) {
-        return;
-      }
-      directWrite("\r" + cursorDown(activePlacement.rowsUp) + hideCursor());
-      activePlacementRef.current = null;
-      // Schedule a deferred re-position in case the layout effect does not
-      // re-run (e.g. a dropdown closed without changing the buffer).
-      Promise.resolve().then(() => {
-        if (unmountingRef.current || activePlacementRef.current) {
-          return;
-        }
-        const latest = directWriteRef.current;
-        const p = lastPlacementRef.current;
-        if (latest && p) {
-          latest(showCursor() + cursorUp(p.rowsUp) + "\r" + cursorForward(p.column));
-          activePlacementRef.current = p;
-        }
-      });
-    };
+
+    directWriteRef.current = directWrite;
+
     const patchedWrite: WriteFn = (...args) => {
-      restorePromptCursor();
+      // Before each write, move the cursor back to the bottom and hide it.
+      if (!unmountingRef.current && activePlacementRef.current) {
+        directWrite("\r" + cursorDown(activePlacementRef.current.rowsUp) + hideCursor());
+        activePlacementRef.current = null;
+      }
       return originalWrite.apply(stdout, args);
     };
 
-    directWriteRef.current = directWrite;
     stream.write = patchedWrite;
-
     return () => {
-      restorePromptCursor();
+      unmountingRef.current = true;
       stream.write = originalWrite;
       directWriteRef.current = null;
     };
-  }, [stdout]);
+  }, [isActive, stdout]);
 
+  // Show and position the terminal cursor after each render.
   useLayoutEffect(() => {
     if (!isActive || !stdout?.isTTY) {
       return;
@@ -196,19 +178,17 @@ export function usePromptTerminalCursor(
 
     directWrite(showCursor() + cursorUp(placement.rowsUp) + "\r" + cursorForward(placement.column));
     activePlacementRef.current = placement;
-    lastPlacementRef.current = placement;
 
     return () => {
       unmountingRef.current = true;
-      lastPlacementRef.current = null;
-      const activePlacement = activePlacementRef.current;
-      if (!activePlacement) {
+      const p = activePlacementRef.current;
+      if (!p) {
         return;
       }
-      directWrite("\r" + cursorDown(activePlacement.rowsUp) + hideCursor());
+      directWrite("\r" + cursorDown(p.rowsUp) + hideCursor());
       activePlacementRef.current = null;
     };
-  }, [isActive, placement.column, placement.rowsUp, stdout]);
+  }, [isActive, placement.rowsUp, placement.column, stdout]);
 }
 
 export function useHiddenTerminalCursor(stdout: NodeJS.WriteStream | undefined, isActive: boolean): void {

--- a/src/ui/prompt/cursor.ts
+++ b/src/ui/prompt/cursor.ts
@@ -40,6 +40,12 @@ function disableTerminalFocusReporting(): string {
   return "\u001B[?1004l";
 }
 
+/**
+ * Calculate where the terminal hardware cursor should be placed relative to
+ * the Ink-rendered inverse cursor cell.  The returned {@code rowsUp} and
+ * {@code column} values are used by {@link usePromptTerminalCursor} to
+ * position the terminal's blinking cursor on top of the simulated inverse cell.
+ */
 export function getPromptCursorPlacement(
   state: PromptBufferState,
   screenWidth: number,
@@ -189,19 +195,6 @@ export function usePromptTerminalCursor(
       activePlacementRef.current = null;
     };
   }, [isActive, placement.rowsUp, placement.column, stdout]);
-}
-
-export function useHiddenTerminalCursor(stdout: NodeJS.WriteStream | undefined, isActive: boolean): void {
-  useLayoutEffect(() => {
-    if (!isActive || !stdout?.isTTY) {
-      return;
-    }
-
-    stdout.write(hideCursor());
-    return () => {
-      stdout.write(showCursor());
-    };
-  }, [isActive, stdout]);
 }
 
 export function useTerminalFocusReporting(stdout: NodeJS.WriteStream | undefined, isActive: boolean): void {

--- a/src/ui/prompt/index.ts
+++ b/src/ui/prompt/index.ts
@@ -1,4 +1,4 @@
 export { useTerminalInput, parseTerminalInput } from "./useTerminalInput";
 export type { InputKey } from "./useTerminalInput";
 
-export { usePromptTerminalCursor, useTerminalFocusReporting, getPromptCursorPlacement, measureTextRows } from "./cursor";
+export { useHiddenTerminalCursor, usePromptTerminalCursor, useTerminalFocusReporting, getPromptCursorPlacement } from "./cursor";

--- a/src/ui/prompt/index.ts
+++ b/src/ui/prompt/index.ts
@@ -1,4 +1,4 @@
 export { useTerminalInput, parseTerminalInput } from "./useTerminalInput";
 export type { InputKey } from "./useTerminalInput";
 
-export { useHiddenTerminalCursor, usePromptTerminalCursor, useTerminalFocusReporting, getPromptCursorPlacement } from "./cursor";
+export { usePromptTerminalCursor, useTerminalFocusReporting, getPromptCursorPlacement, measureTextRows } from "./cursor";

--- a/src/ui/prompt/useTerminalInput.ts
+++ b/src/ui/prompt/useTerminalInput.ts
@@ -20,8 +20,6 @@ export type InputKey = {
   meta: boolean;
   focusIn: boolean;
   focusOut: boolean;
-  /** The input was received as part of a bracketed paste (sent by the terminal). */
-  paste: boolean;
 };
 
 const BACKSPACE_BYTES = new Set(["\u007F", "\b"]);
@@ -36,9 +34,6 @@ const META_LEFT_SEQUENCES = new Set(["\u001B[1;3D", "\u001B[3D", "\u001Bb"]);
 const META_RIGHT_SEQUENCES = new Set(["\u001B[1;3C", "\u001B[3C", "\u001Bf"]);
 const TERMINAL_FOCUS_IN = "\u001B[I";
 const TERMINAL_FOCUS_OUT = "\u001B[O";
-/** Bracketed paste mode markers: start and end delimiters sent by terminals. */
-const BRACKETED_PASTE_START = "\u001B[200~";
-const BRACKETED_PASTE_END = "\u001B[201~";
 
 export function parseTerminalInput(data: Buffer | string): { input: string; key: InputKey } {
   const raw = String(data);
@@ -61,8 +56,7 @@ export function parseTerminalInput(data: Buffer | string): { input: string; key:
     delete: FORWARD_DELETE_SEQUENCES.has(raw),
     meta: META_LEFT_SEQUENCES.has(raw) || META_RIGHT_SEQUENCES.has(raw) || META_RETURN_SEQUENCES.has(raw),
     focusIn: raw === TERMINAL_FOCUS_IN,
-    focusOut: raw === TERMINAL_FOCUS_OUT,
-    paste: false
+    focusOut: raw === TERMINAL_FOCUS_OUT
   };
 
   if (input <= "\u001A" && !key.return) {
@@ -117,9 +111,6 @@ export function useTerminalInput(
   const isActive = options.isActive ?? true;
   const handlerRef = useRef(inputHandler);
   handlerRef.current = inputHandler;
-  // Accumulates text between bracketed paste start and end markers.
-  // Non-null means a paste is in progress.
-  const pasteRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!isActive) {
@@ -136,37 +127,6 @@ export function useTerminalInput(
       return;
     }
     const handleData = (data: Buffer | string) => {
-      const raw = String(data);
-
-      // Bracketed paste mode: the terminal wraps pasted content in
-      // \u001B[200~ (start) and \u001B[201~ (end).  Accumulate everything
-      // between them and deliver as a single input chunk with
-      // normalized line endings.
-      if (raw === "\u001B[200~") {
-        pasteRef.current = "";
-        return;
-      }
-      if (raw === "\u001B[201~") {
-        const pasted = pasteRef.current;
-        pasteRef.current = null;
-        if (pasted != null && pasted.length > 0) {
-          // Normalize any line-ending variant to \n.
-          const normalized = pasted.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
-          handlerRef.current(normalized, {
-            upArrow: false, downArrow: false, leftArrow: false, rightArrow: false,
-            home: false, end: false, pageDown: false, pageUp: false,
-            return: false, escape: false, ctrl: false, shift: false,
-            tab: false, backspace: false, delete: false, meta: false,
-            focusIn: false, focusOut: false, paste: true
-          });
-        }
-        return;
-      }
-      if (typeof pasteRef.current === "string") {
-        pasteRef.current += raw;
-        return;
-      }
-
       const { input, key } = parseTerminalInput(data);
       handlerRef.current(input, key);
     };

--- a/src/ui/prompt/useTerminalInput.ts
+++ b/src/ui/prompt/useTerminalInput.ts
@@ -20,6 +20,8 @@ export type InputKey = {
   meta: boolean;
   focusIn: boolean;
   focusOut: boolean;
+  /** The input was received as part of a bracketed paste (sent by the terminal). */
+  paste: boolean;
 };
 
 const BACKSPACE_BYTES = new Set(["\u007F", "\b"]);
@@ -34,6 +36,9 @@ const META_LEFT_SEQUENCES = new Set(["\u001B[1;3D", "\u001B[3D", "\u001Bb"]);
 const META_RIGHT_SEQUENCES = new Set(["\u001B[1;3C", "\u001B[3C", "\u001Bf"]);
 const TERMINAL_FOCUS_IN = "\u001B[I";
 const TERMINAL_FOCUS_OUT = "\u001B[O";
+/** Bracketed paste mode markers: start and end delimiters sent by terminals. */
+const BRACKETED_PASTE_START = "\u001B[200~";
+const BRACKETED_PASTE_END = "\u001B[201~";
 
 export function parseTerminalInput(data: Buffer | string): { input: string; key: InputKey } {
   const raw = String(data);
@@ -56,7 +61,8 @@ export function parseTerminalInput(data: Buffer | string): { input: string; key:
     delete: FORWARD_DELETE_SEQUENCES.has(raw),
     meta: META_LEFT_SEQUENCES.has(raw) || META_RIGHT_SEQUENCES.has(raw) || META_RETURN_SEQUENCES.has(raw),
     focusIn: raw === TERMINAL_FOCUS_IN,
-    focusOut: raw === TERMINAL_FOCUS_OUT
+    focusOut: raw === TERMINAL_FOCUS_OUT,
+    paste: false
   };
 
   if (input <= "\u001A" && !key.return) {
@@ -111,6 +117,9 @@ export function useTerminalInput(
   const isActive = options.isActive ?? true;
   const handlerRef = useRef(inputHandler);
   handlerRef.current = inputHandler;
+  // Accumulates text between bracketed paste start and end markers.
+  // Non-null means a paste is in progress.
+  const pasteRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!isActive) {
@@ -127,6 +136,37 @@ export function useTerminalInput(
       return;
     }
     const handleData = (data: Buffer | string) => {
+      const raw = String(data);
+
+      // Bracketed paste mode: the terminal wraps pasted content in
+      // \u001B[200~ (start) and \u001B[201~ (end).  Accumulate everything
+      // between them and deliver as a single input chunk with
+      // normalized line endings.
+      if (raw === "\u001B[200~") {
+        pasteRef.current = "";
+        return;
+      }
+      if (raw === "\u001B[201~") {
+        const pasted = pasteRef.current;
+        pasteRef.current = null;
+        if (pasted != null && pasted.length > 0) {
+          // Normalize any line-ending variant to \n.
+          const normalized = pasted.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+          handlerRef.current(normalized, {
+            upArrow: false, downArrow: false, leftArrow: false, rightArrow: false,
+            home: false, end: false, pageDown: false, pageUp: false,
+            return: false, escape: false, ctrl: false, shift: false,
+            tab: false, backspace: false, delete: false, meta: false,
+            focusIn: false, focusOut: false, paste: true
+          });
+        }
+        return;
+      }
+      if (typeof pasteRef.current === "string") {
+        pasteRef.current += raw;
+        return;
+      }
+
       const { input, key } = parseTerminalInput(data);
       handlerRef.current(input, key);
     };


### PR DESCRIPTION
## feat(ui): 实现终端提示输入和命令菜单组件
-  cloes #4 
-  cloes #5

## fix(prompt): 优化光标定位和命令菜单渲染
- 将光标定位函数参数从 footerText 修改为 belowRows，更灵活表示下方行数占用
- 修正渲染光标时隐藏和显示终端光标，防止光标闪烁和位置错误
- 在 PromptInput 组件中动态计算命令菜单行数，根据菜单展开调整光标位置
- 添加 BufferWithCursor 组件替代旧的光标渲染逻辑，更好支持焦点状态和占位符
- 新增 SlashCommandMenu 组件，实现带滚动箭头和导航提示的命令菜单显示
- 调整 MessageView 和 PromptInput 样式，优化边距和边框显示
- 增加大量单元测试，覆盖输入解析和光标定位等核心功能

## fix (terminal): 优化终端粘贴输入处理
- 支持终端的括号粘贴模式，准确识别粘贴开始和结束标记
- 在括号粘贴过程中累积文本，确保一次性处理完整粘贴内容
- 标准化行结束符，将 Windows 和旧 macOS 换行统一为 \n
- 修改通用输入处理，保持多行内容格式不变，提升用户粘贴体验
- 在输入事件中新增 paste 标志，区分普通输入与粘贴输入

## style(ui): 优化命令菜单及输入提示的高亮颜色表现
- 把 PromptInput 中非忙碌状态的提示文字颜色从绿色改为更柔和的蓝色 (#229ac3)
- 将 SlashCommandMenu 中选中项的文字颜色由预设的 cyanBright 改为统一的蓝色 (#229ac3)
- 在 PromptInput 中添加对 showMenu 的条件判断，控制底部文字的显示避免 UI 冗余
- 统一并优化了命令菜单及提示输入的颜色风格，提高界面视觉一致性