### PR TITLE
chore(types): 添加 @types/ejs 依赖以支持模板类型定义

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@types/ejs": "^3.1.5",
         "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
         "esbuild": "^0.28.0",
@@ -1026,6 +1027,13 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@types/ejs": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmmirror.com/@types/ejs/-/ejs-3.1.5.tgz",
+      "integrity": "sha512-nv+GSx77ZtXiJzwKdsASqi+YQ5Z7vwHsTP0JY2SiQgjGckkBRKZnk8nIM+7oUZ1VCtuTz0+By4qVR7fqzp/Dfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@types/ejs": "^3.1.5",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "esbuild": "^0.28.0",

--- a/src/session.ts
+++ b/src/session.ts
@@ -2,9 +2,9 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 import * as crypto from "crypto";
-import { createRequire } from "module";
 import { fileURLToPath } from "url";
 import matter from "gray-matter";
+import ejs from "ejs";
 import type { ChatCompletionMessageParam, ChatCompletionContentPart } from "openai/resources/chat/completions";
 import { launchNotifyScript } from "./notify";
 import { buildThinkingRequestOptions } from "./openai-thinking";
@@ -18,10 +18,6 @@ const MAX_SESSION_ENTRIES = 50;
 const DEFAULT_NEW_PROMPT_API_URL = "https://deepcode.vegamo.cn/api/plugin/new";
 const DEFAULT_COMPACT_PROMPT_TOKEN_THRESHOLD = 128 * 1024;
 const DEEPSEEK_V4_COMPACT_PROMPT_TOKEN_THRESHOLD = 512 * 1024;
-const require = createRequire(import.meta.url);
-const ejs = require("ejs") as {
-  render: (template: string, data?: Record<string, unknown>) => string;
-};
 
 type ChatCompletionDebugOptions = {
   enabled?: boolean;


### PR DESCRIPTION
- 在 package.json 和 package-lock.json 中新增 @types/ejs 开发依赖
- 在 session.ts 中直接使用 ejs 模块替代原先动态 require 方式
- 移除 session.ts 中的 createRequire 相关代码，简化模块引入逻辑