### PR TITLE
feat: 支持 Emacs 风格的 Meta 删词快捷键

### DIFF
--- a/src/tests/promptBuffer.test.ts
+++ b/src/tests/promptBuffer.test.ts
@@ -5,6 +5,7 @@ import {
   backspace,
   deleteForward,
   deleteWordBefore,
+  deleteWordAfter,
   getCurrentSlashToken,
   insertText,
   killLine,
@@ -92,6 +93,12 @@ test("deleteWordBefore removes the previous word and any adjacent whitespace", (
   const result = deleteWordBefore({ text: "ask the model", cursor: 8 });
   assert.equal(result.text, "ask model");
   assert.equal(result.cursor, 4);
+});
+
+test("deleteWordAfter removes the next word and leading whitespace", () => {
+  const result = deleteWordAfter({ text: "ask the model now", cursor: 3 });
+  assert.equal(result.text, "ask model now");
+  assert.equal(result.cursor, 3);
 });
 
 test("getCurrentSlashToken returns the slash word at the cursor", () => {

--- a/src/tests/promptInputKeys.test.ts
+++ b/src/tests/promptInputKeys.test.ts
@@ -60,6 +60,20 @@ test("parseTerminalInput recognizes word navigation modifiers", () => {
   assert.equal(metaRight.key.meta, true);
 });
 
+test("parseTerminalInput keeps DEL payload for meta+backspace", () => {
+  const { input, key } = parseTerminalInput("\u001B\u007F");
+  assert.equal(input, "\u007F");
+  assert.equal(key.meta, true);
+  assert.equal(key.backspace, false);
+});
+
+test("parseTerminalInput keeps BS payload for meta+backspace", () => {
+  const { input, key } = parseTerminalInput("\u001B\b");
+  assert.equal(input, "\b");
+  assert.equal(key.meta, true);
+  assert.equal(key.backspace, false);
+});
+
 test("parseTerminalInput recognizes shifted return sequences", () => {
   const { input, key } = parseTerminalInput("\u001B\r");
   assert.equal(input, "\r");

--- a/src/ui/PromptInput.tsx
+++ b/src/ui/PromptInput.tsx
@@ -6,6 +6,7 @@ import {
   backspace,
   deleteForward,
   deleteWordBefore,
+  deleteWordAfter,
   getCurrentSlashToken,
   insertText,
   isEmpty,
@@ -400,11 +401,18 @@ export const PromptInput = React.memo(function PromptInput({
         updateBuffer((s) => deleteWordBefore(s));
         return;
       }
+      if (key.meta && (input === "d" || input === "D")) {
+        updateBuffer((s) => deleteWordAfter(s));
+        return;
+      }
+      if (key.meta && (input === "\u007F" || input === "\b")) {
+        updateBuffer((s) => deleteWordBefore(s));
+        return;
+      }
       if (key.ctrl && (input === "j" || input === "J")) {
         updateBuffer((s) => insertText(s, "\n"));
         return;
       }
-
       if (input.startsWith("\u001B")) {
         // Unhandled escape sequence (e.g. function keys); ignore to avoid inserting garbage.
         return;

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -49,6 +49,7 @@ export {
   moveLineEnd,
   killLine,
   deleteWordBefore,
+  deleteWordAfter,
   reset,
   isEmpty,
   getCurrentSlashToken,

--- a/src/ui/promptBuffer.ts
+++ b/src/ui/promptBuffer.ts
@@ -127,6 +127,24 @@ export function deleteWordBefore(state: PromptBufferState): PromptBufferState {
   };
 }
 
+export function deleteWordAfter(state: PromptBufferState): PromptBufferState {
+  const start = state.cursor;
+  let end = start;
+  while (end < state.text.length && /\s/.test(state.text[end] ?? "")) {
+    end++;
+  }
+  while (end < state.text.length && !/\s/.test(state.text[end] ?? "")) {
+    end++;
+  }
+  if (start === end) {
+    return state;
+  }
+  return {
+    text: state.text.slice(0, start) + state.text.slice(end),
+    cursor: start,
+  };
+}
+
 export function reset(): PromptBufferState {
   return { ...EMPTY_BUFFER };
 }


### PR DESCRIPTION
## 变更说明
- 在输入框支持 Meta+d 删除光标后一个词
- 支持 Meta+Backspace 删除光标前一个词（兼容 ESC+DEL 与 ESC+BS）
- 补充对应单测

## 影响
- 不改变现有 Ctrl+f / Ctrl+b / Ctrl+k 行为，仅补齐常见 Emacs 快捷键。