### PR TITLE
fix(ui): 终端 resize 后重绘输入区并保留 scrollback 历史

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -248,6 +248,37 @@ export function App({ projectRoot, version = "", onRestart }: AppProps): React.R
     const timer = setTimeout(() => setStableColumns(columns), 100);
     return () => clearTimeout(timer);
   }, [columns]);
+  const lastRenderedColumnsRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!stdout?.isTTY) {
+      return;
+    }
+    if (stableColumns <= 0) {
+      return;
+    }
+    if (lastRenderedColumnsRef.current === null) {
+      lastRenderedColumnsRef.current = stableColumns;
+      return;
+    }
+    if (lastRenderedColumnsRef.current === stableColumns) {
+      return;
+    }
+    lastRenderedColumnsRef.current = stableColumns;
+
+    // Force full redraw on terminal resize to avoid stale wrapped rows.
+    writeRef.current("\u001B[2J\u001B[H");
+    setMessages([]);
+    setShowWelcome(false);
+    setWelcomeNonce((n) => n + 1);
+
+    const activeSessionId = sessionManager.getActiveSessionId();
+    const nextMessages =
+      activeSessionId && !busy ? loadVisibleMessages(sessionManager, activeSessionId) : messagesRef.current;
+    setTimeout(() => {
+      setMessages(nextMessages);
+      setShowWelcome(true);
+    }, 0);
+  }, [busy, sessionManager, stableColumns, stdout]);
   const screenWidth = useMemo(() => stableColumns ?? stdout?.columns ?? 80, [stableColumns, stdout]);
   const promptHistory = useMemo(() => {
     return messages


### PR DESCRIPTION
### 背景

<img width="1650" height="1006" alt="image" src="https://github.com/user-attachments/assets/004e014d-5819-44ef-b0cc-0e24c27ecb6a" />


在终端窗口尺寸变化后，界面会出现历史行残留，导致输入区域出现视觉叠加。

目前逻辑向 Claude Code 对齐，清屏的同时保留之前的历史记录，用户上滚动依旧查看历史输出。

### 变更内容

- 在 App 中监听稳定后的列宽变化（stableColumns）
- 当检测到终端宽度变化时：
  - 执行当前屏重绘（ESC[2J + ESC[H）
  - 重置并重新挂载静态消息区域，避免旧换行残留导致的叠加

### 验证

- [x] npm run typecheck 通过
- [x] npm run test -- src/tests/promptInputKeys.test.ts 通过
- [x] 本地 npm run build 通过（依赖完整安装后）

### 影响范围

- 仅涉及 UI 渲染刷新时机与清屏策略
- 不改变业务逻辑与会话数据
- 改善 resize 场景下的输入区可用性，并保留 terminal 历史滚动能力
