### PR TITLE
fix: support DEEPSEEK_API_KEY environment variable

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,6 +4,7 @@ export type DeepcodingEnv = {
   MODEL?: string;
   BASE_URL?: string;
   API_KEY?: string;
+  DEEPSEEK_API_KEY?: string;
   THINKING?: string;
 };
 
@@ -61,9 +62,19 @@ function resolveThinkingEnabled(settings: DeepcodingSettings | null | undefined,
   return defaultsToThinkingMode(model);
 }
 
+function trimmedValue(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+function resolveApiKey(env: DeepcodingEnv, runtimeEnv: NodeJS.ProcessEnv): string | undefined {
+  return trimmedValue(env.API_KEY) || trimmedValue(env.DEEPSEEK_API_KEY) || trimmedValue(runtimeEnv.DEEPSEEK_API_KEY);
+}
+
 export function resolveSettings(
   settings: DeepcodingSettings | null | undefined,
-  defaults: { model: string; baseURL: string }
+  defaults: { model: string; baseURL: string },
+  runtimeEnv: NodeJS.ProcessEnv = process.env
 ): ResolvedDeepcodingSettings {
   const env = settings?.env ?? {};
   const topLevelModel = typeof settings?.model === "string" ? settings.model.trim() : "";
@@ -74,7 +85,7 @@ export function resolveSettings(
   const mcpServers = settings?.mcpServers;
 
   return {
-    apiKey: env.API_KEY?.trim(),
+    apiKey: resolveApiKey(env, runtimeEnv),
     baseURL: env.BASE_URL?.trim() || defaults.baseURL,
     model,
     thinkingEnabled: resolveThinkingEnabled(settings, model),

--- a/src/tests/settings-and-notify.test.ts
+++ b/src/tests/settings-and-notify.test.ts
@@ -33,6 +33,45 @@ test("resolveSettings reads top-level thinkingEnabled, notify, and webSearchTool
   assert.equal(resolved.webSearchTool, "/tmp/web-search.sh");
 });
 
+test("resolveSettings uses DEEPSEEK_API_KEY when settings omit API_KEY", () => {
+  const resolved = resolveSettings(
+    {
+      env: {
+        MODEL: "deepseek-v4-pro",
+        BASE_URL: "https://api.deepseek.com",
+      },
+    },
+    {
+      model: "default-model",
+      baseURL: "https://default.example.com",
+    },
+    {
+      DEEPSEEK_API_KEY: "  sk-from-env  ",
+    }
+  );
+
+  assert.equal(resolved.apiKey, "sk-from-env");
+});
+
+test("resolveSettings gives settings API_KEY priority over DEEPSEEK_API_KEY", () => {
+  const resolved = resolveSettings(
+    {
+      env: {
+        API_KEY: "sk-from-settings",
+      },
+    },
+    {
+      model: "default-model",
+      baseURL: "https://default.example.com",
+    },
+    {
+      DEEPSEEK_API_KEY: "sk-from-env",
+    }
+  );
+
+  assert.equal(resolved.apiKey, "sk-from-settings");
+});
+
 test("resolveSettings gives top-level model priority over env MODEL", () => {
   const resolved = resolveSettings(
     {


### PR DESCRIPTION
Closes #22

This adds support for using DEEPSEEK_API_KEY from the runtime environment when no API_KEY is configured in ~/.deepcode/settings.json.

Existing settings env.API_KEY keeps priority, so current users are not affected.
