### PR TITLE
refactor(session): 简化并统一会话系统消息的处理逻辑

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -122,11 +122,6 @@ export type MessageMeta = {
   asThinking?: boolean;
   isSummary?: boolean;
   isModelChange?: boolean;
-  modelConfig?: {
-    model: string;
-    thinkingEnabled: boolean;
-    reasoningEffort?: string;
-  };
   skill?: SkillInfo;
 };
 
@@ -778,6 +773,12 @@ The candidate skills are as follows:\n\n`;
     this.activeSessionId = sessionId;
   }
 
+  addSessionSystemMessage(sessionId: string, content: string, meta?: MessageMeta): void {
+    const message = this.buildSystemMessage(sessionId, content, meta);
+    this.appendSessionMessage(sessionId, message);
+    this.onAssistantMessage(message, false);
+  }
+
   async handleUserPrompt(userPrompt: UserPromptContent): Promise<void> {
     const controller = new AbortController();
     this.activePromptController = controller;
@@ -1332,25 +1333,6 @@ ${skillMd}
     return messages;
   }
 
-  addSessionSystemMessage(sessionId: string, content: string, meta?: MessageMeta): void {
-    const now = new Date().toISOString();
-    const message: SessionMessage = {
-      id: crypto.randomUUID(),
-      sessionId,
-      role: "system",
-      content,
-      contentParams: null,
-      messageParams: null,
-      compacted: false,
-      visible: true,
-      createTime: now,
-      updateTime: now,
-      meta,
-    };
-    this.appendSessionMessage(sessionId, message);
-    this.onAssistantMessage(message, false);
-  }
-
   private normalizeSessionMessage(message: SessionMessage): SessionMessage {
     if (message.role !== "tool") {
       return message;
@@ -1560,7 +1542,12 @@ ${skillMd}
     return this.readNonEmptyFile(path.join(os.homedir(), ".deepcode", "AGENTS.md"));
   }
 
-  private buildSystemMessage(sessionId: string, content: string, contentParams: unknown | null = null): SessionMessage {
+  private buildSystemMessage(
+    sessionId: string,
+    content: string,
+    contentParams: unknown | null = null,
+    meta?: MessageMeta
+  ): SessionMessage {
     const now = new Date().toISOString();
     return {
       id: crypto.randomUUID(),
@@ -1573,6 +1560,7 @@ ${skillMd}
       visible: false,
       createTime: now,
       updateTime: now,
+      meta,
     };
   }
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -277,13 +277,8 @@ export function App({ projectRoot, version = "", onRestart }: AppProps): React.R
       const activeSessionId = sessionManager.getActiveSessionId();
       const meta: MessageMeta = {
         isModelChange: true,
-        modelConfig: {
-          model: selection.model,
-          thinkingEnabled: selection.thinkingEnabled,
-          reasoningEffort: selection.reasoningEffort,
-        },
       };
-      const content = `/model\n└ Set model to ${selection.model}`;
+      const content = `/model\n└ Set model to ${selection.model} (${selection?.reasoningEffort || "no thinking"})`;
 
       if (activeSessionId) {
         sessionManager.addSessionSystemMessage(activeSessionId, content, meta);

--- a/src/ui/MessageView.tsx
+++ b/src/ui/MessageView.tsx
@@ -89,14 +89,7 @@ export function MessageView({ message, collapsed }: Props): React.ReactElement |
             <Text color="#229ac3">{`>`}</Text>
           </Box>
           <Box flexGrow={1} flexDirection="column">
-            <Text color="cyan">/model</Text>
-            <Text color="cyan">
-              └ Set model to{" "}
-              <Text bold color="#229ac3">
-                {message.meta.modelConfig?.model}
-              </Text>
-              <Text dimColor>{`  (${message.meta.modelConfig?.reasoningEffort || "normal"} effort)`}</Text>
-            </Text>
+            <Text color="#229ac3">{message.content}</Text>
           </Box>
         </Box>
       );


### PR DESCRIPTION
- 移除多余的 modelConfig 属性，改用 message.content 直接展示模型和思考力度信息
- 优化 App.tsx 中系统消息内容的格式，加入推理力度显示
- MessageView.tsx 改为直接渲染 message.content，简化展示逻辑
- 在 session.ts 中整合 addSessionSystemMessage 方法，避免重复定义
- 构建系统消息时支持传入 meta 信息，增强消息元数据灵活性