### PR TITLE
fix(ui): 修正 reasoningEffort 显示逻辑

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -278,7 +278,7 @@ export function App({ projectRoot, version = "", onRestart }: AppProps): React.R
       const meta: MessageMeta = {
         isModelChange: true,
       };
-      const content = `/model\n└ Set model to ${selection.model} (${selection?.reasoningEffort || "no thinking"})`;
+      const content = `/model\n└ Set model to ${selection.model} (${selection?.thinkingEnabled ? selection?.reasoningEffort : "no thinking"})`;
 
       if (activeSessionId) {
         sessionManager.addSessionSystemMessage(activeSessionId, content, meta);

--- a/src/ui/WelcomeScreen.tsx
+++ b/src/ui/WelcomeScreen.tsx
@@ -68,7 +68,7 @@ export function WelcomeScreen({
             {!compact ? <Text> </Text> : null}
             <SettingRow label="Model" value={settings.model} />
             <SettingRow label="Thinking Enabled" value={String(settings.thinkingEnabled)} />
-            <SettingRow label="Reasoning Effort" value={settings.reasoningEffort} />
+            <SettingRow label="Reasoning Effort" value={settings.thinkingEnabled ? settings.reasoningEffort : "-"} />
             <SettingRow label="CWD" value={cwd} />
           </Box>
         </Box>


### PR DESCRIPTION
- 修改模型切换消息内容，基于thinkingEnabled状态显示reasoningEffort
- 调整欢迎界面中Reasoning Effort的显示，当thinkingEnabled为false时显示“-”