### PR TITLE
feat: 添加 GitHub CI 工作流，支持多平台多版本自动验证

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,8 @@
 name: CI
 
 on:
-  pull_request:
-    branches: [main]
   push:
+  pull_request:
     branches: [main]
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    name: Node ${{ matrix.node-version }} / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+        node-version:
+          - "18"
+          - "20"
+          - "22"
+          - "24"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: TypeCheck + Lint + Format Check
+        run: npm run check
+
+      - name: Bundle
+        run: npm run bundle
+
+      - name: Test
+        run: npm test


### PR DESCRIPTION
## 变更内容

为项目添加 GitHub Actions CI 工作流，每次 PR 时自动执行构建和测试验证。

### CI 矩阵

| 维度 | 覆盖范围 |
|---|---|
| **操作系统** | Ubuntu、Windows、macOS |
| **Node.js 版本** | 18、20、22、24 |
| **并行 Job 数** | 3 × 4 = 12 |

### 验证步骤

1. `npm ci` — 安装依赖
2. `npm run check` — TypeScript 类型检查 + ESLint + Prettier 格式校验
3. `npm run bundle` — esbuild 构建
4. `npm test` — 运行测试套件

### 触发条件

- PR 到 `main` 分支
- push 到 `main` 分支

### 其他

- `fail-fast: false`，单个 job 失败不会取消其他 job
- 启用了 `actions/setup-node` 的 npm 缓存，加速后续运行