### PR TITLE
feat: add -p/--prompt flag to auto-submit prompt on launch

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -18,9 +18,11 @@ if (args.includes("--help") || args.includes("-h")) {
       "deepcode - Deep Code CLI",
       "",
       "Usage:",
-      "  deepcode               Launch the interactive TUI in the current directory",
-      "  deepcode --version     Print the version",
-      "  deepcode --help        Show this help",
+      "  deepcode                              Launch the interactive TUI in the current directory",
+      "  deepcode -p <prompt>                  Launch with a pre-filled prompt",
+      "  deepcode --prompt <prompt>            Same as -p",
+      "  deepcode --version                    Print the version",
+      "  deepcode --help                       Show this help",
       "",
       "Configuration:",
       "  ~/.deepcode/settings.json    User-level API key, model, base URL",
@@ -50,6 +52,15 @@ if (args.includes("--help") || args.includes("-h")) {
   process.exit(0);
 }
 
+function extractInitialPrompt(args: string[]): string | undefined {
+  const promptIndex = args.findIndex((arg) => arg === "-p" || arg === "--prompt");
+  if (promptIndex !== -1 && promptIndex + 1 < args.length) {
+    return args[promptIndex + 1];
+  }
+  return undefined;
+}
+
+const initialPrompt = extractInitialPrompt(args);
 const projectRoot = process.cwd();
 configureWindowsShell();
 
@@ -68,7 +79,12 @@ async function main(): Promise<void> {
   function startApp(): void {
     let restarting = false;
     const inkInstance = render(
-      <App projectRoot={projectRoot} version={packageInfo.version} onRestart={() => restartRef.current?.()} />,
+      <App
+        projectRoot={projectRoot}
+        version={packageInfo.version}
+        initialPrompt={initialPrompt}
+        onRestart={() => restartRef.current?.()}
+      />,
       { exitOnCtrlC: false }
     );
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -45,10 +45,11 @@ type View = "chat" | "session-list" | "mcp-status";
 type AppProps = {
   projectRoot: string;
   version?: string;
+  initialPrompt?: string;
   onRestart?: () => void;
 };
 
-export function App({ projectRoot, version = "", onRestart }: AppProps): React.ReactElement {
+export function App({ projectRoot, version = "", initialPrompt, onRestart }: AppProps): React.ReactElement {
   const { exit } = useApp();
   const { stdout, write } = useStdout();
   const { columns } = useWindowSize();
@@ -470,6 +471,7 @@ export function App({ projectRoot, version = "", onRestart }: AppProps): React.R
           promptHistory={promptHistory}
           busy={busy}
           loadingText={loadingText}
+          initialPrompt={initialPrompt}
           onSubmit={handleSubmit}
           onModelConfigChange={handleModelConfigChange}
           onInterrupt={handleInterrupt}

--- a/src/ui/PromptInput.tsx
+++ b/src/ui/PromptInput.tsx
@@ -60,6 +60,7 @@ type Props = {
   loadingText?: string | null;
   disabled?: boolean;
   placeholder?: string;
+  initialPrompt?: string;
   onSubmit: (submission: PromptSubmission) => void;
   onModelConfigChange: (selection: ModelConfigSelection) => string | Promise<string>;
   onInterrupt: () => void;
@@ -109,13 +110,16 @@ export const PromptInput = React.memo(function PromptInput({
   loadingText,
   disabled,
   placeholder,
+  initialPrompt,
   onSubmit,
   onModelConfigChange,
   onInterrupt,
 }: Props): React.ReactElement {
   const { exit } = useApp();
   const { stdout } = useStdout();
-  const [buffer, setBuffer] = useState<PromptBufferState>(EMPTY_BUFFER);
+  const [buffer, setBuffer] = useState<PromptBufferState>(() =>
+    initialPrompt ? { text: initialPrompt, cursor: initialPrompt.length } : EMPTY_BUFFER
+  );
   const [imageUrls, setImageUrls] = useState<string[]>([]);
   const [selectedSkills, setSelectedSkills] = useState<SkillInfo[]>([]);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
@@ -191,6 +195,19 @@ export const PromptInput = React.memo(function PromptInput({
     setHistoryCursor(-1);
     setDraftBeforeHistory(null);
   }, [promptHistoryKey]);
+
+  // Auto-submit initial prompt provided via -p/--prompt CLI flag
+  useEffect(() => {
+    if (!initialPrompt || !initialPrompt.trim()) return;
+
+    onSubmit({
+      text: initialPrompt,
+      imageUrls: [],
+      selectedSkills: undefined,
+    });
+    setBuffer(EMPTY_BUFFER);
+    clearPromptUndoRedoState(undoRedoRef.current);
+  }, []); // Only on mount
 
   useTerminalInput(
     (input, key) => {


### PR DESCRIPTION
Adds CLI argument -p / --prompt that takes a prompt string and auto-submits it immediately when deepcode starts.

Usage:
  deepcode -p 'write a Python script'
  deepcode --prompt 'write a Python script'
就是增加一个claude code也有的功能
比如
deepcode -p 你好
然后打开就是一个你好已经发送出去的deepcode