### PR TITLE
feat: status line 显示会话累计 tokens 和请求次数

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -760,11 +760,22 @@ function isCurrentSessionEmpty(sessionManager: SessionManager): boolean {
   return !activeSessionId || !sessionManager.getSession(activeSessionId);
 }
 
+function formatTokenCount(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 10000) return `${(n / 1000).toFixed(1)}k`;
+  return `${Math.round(n / 1000)}k`;
+}
+
 function buildStatusLine(entry: SessionEntry): string {
   const parts: string[] = [];
   parts.push(`status: ${entry.status}`);
-  if (typeof entry.activeTokens === "number" && entry.activeTokens > 0) {
-    parts.push(`tokens: ${entry.activeTokens}`);
+  const totalTokens = entry.usage?.total_tokens ?? 0;
+  const totalReqs =
+    entry.usagePerModel != null
+      ? Object.values(entry.usagePerModel).reduce((sum, m) => sum + (m.total_reqs ?? 0), 0)
+      : 0;
+  if (totalTokens > 0) {
+    parts.push(`tokens: ${formatTokenCount(totalTokens)}${totalReqs > 0 ? ` / ${totalReqs} reqs` : ""}`);
   }
   if (entry.failReason) {
     parts.push(`fail: ${entry.failReason}`);


### PR DESCRIPTION
## 改动

`buildStatusLine()` 中 tokens 展示从 `activeTokens`（仅最近一次 API 响应）改为**会话累计值**：

```
之前：status: processing · tokens: 1234
之后：status: processing · tokens: 12.3k / 5 reqs
```

## 数据来源

- `totalTokens`：`entry.usage.total_tokens`（会话累计，每次 API 调用累加）
- `totalReqs`：`entry.usagePerModel` 各模型的 `total_reqs` 求和（已有跟踪链路）
- 格式化：<1000 直显，<10000 显示 `1.2k`，>=10000 显示 `12k`

## 为什么不用 activeTokens

`activeTokens` 存储的是最近一次 API 响应的 `total_tokens`（`session.ts:1221`），只用于 compaction 阈值比较，不是累计值。`entry.usage.total_tokens` 才是真正的会话累计。