### PR TITLE
refactor(ui): 使用 resetPromptInput 简化撤销和回绕处理

### DIFF
--- a/src/tests/tool-executor.test.ts
+++ b/src/tests/tool-executor.test.ts
@@ -29,9 +29,9 @@ test("ToolExecutor accepts title-case built-in tool aliases", async () => {
       type: "function",
       function: {
         name: "Read",
-        arguments: JSON.stringify({ file_path: filePath })
-      }
-    }
+        arguments: JSON.stringify({ file_path: filePath }),
+      },
+    },
   ]);
 
   assert.equal(executions.length, 1);

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -93,7 +93,7 @@ const BUILT_IN_TOOL_NAME_ALIASES = new Map<string, string>([
   ["Bash", "bash"],
   ["Read", "read"],
   ["Write", "write"],
-  ["Edit", "edit"]
+  ["Edit", "edit"],
 ]);
 
 export type ToolCallExecution = {

--- a/src/ui/PromptInput.tsx
+++ b/src/ui/PromptInput.tsx
@@ -659,11 +659,7 @@ export const PromptInput = React.memo(function PromptInput({
     }
     if (item.kind === "undo") {
       onSubmit({ text: "/undo", imageUrls: [], command: "undo" });
-      setBuffer(EMPTY_BUFFER);
-      clearUndoRedoStacks();
-      setImageUrls([]);
-      setSelectedSkills([]);
-      setShowSkillsDropdown(false);
+      resetPromptInput();
       return;
     }
     if (item.kind === "mcp") {


### PR DESCRIPTION
- 替换手动状态重置为调用 resetPromptInput 函数
- 简化代码提高可读性和维护性