### PR TITLE
feat(ui): add bracketed paste with large-paste marker collapsing

### DIFF
--- a/src/ui/PromptInput.tsx
+++ b/src/ui/PromptInput.tsx
@@ -188,7 +188,7 @@ export const PromptInput = React.memo(function PromptInput({
   const showMenu = slashMenu.length > 0;
   const promptHistoryKey = React.useMemo(() => promptHistory.join("\0"), [promptHistory]);
   const hasRunningProcess = runningProcesses && runningProcesses.size > 0;
-  const hasCollapsedMarkers = hasActivePasteMarkers(buffer.text);
+  const hasCollapsedMarkers = hasActivePasteMarkers(buffer.text, pastesRef.current);
   const hasExpandedRegions = expandedRegionsRef.current.size > 0;
   const processOrPasteHint = hasRunningProcess
     ? " · ctrl+o view output"
@@ -431,12 +431,12 @@ export const PromptInput = React.memo(function PromptInput({
       }
 
       if (key.delete) {
-        updateBuffer((s) => deletePasteMarkerForward(s) ?? deleteForward(s));
+        updateBuffer((s) => deletePasteMarkerForward(s, pastesRef.current) ?? deleteForward(s));
         return;
       }
 
       if (key.backspace) {
-        updateBuffer((s) => deletePasteMarkerBackward(s) ?? backspace(s));
+        updateBuffer((s) => deletePasteMarkerBackward(s, pastesRef.current) ?? backspace(s));
         return;
       }
 
@@ -872,7 +872,7 @@ export const PromptInput = React.memo(function PromptInput({
         borderDimColor
       >
         <PromptPrefixLine busy={busy} />
-        <Text>{renderBufferWithCursor(buffer, !disabled && hasTerminalFocus, placeholder)}</Text>
+        <Text>{renderBufferWithCursor(buffer, !disabled && hasTerminalFocus, placeholder, pastesRef.current)}</Text>
         {inlineHint ? <Text dimColor>{inlineHint}</Text> : null}
       </Box>
       <RawModelDropdown
@@ -986,9 +986,15 @@ export function getPromptReturnKeyAction(key: Pick<InputKey, "return" | "shift" 
   return "submit";
 }
 
-export function renderBufferWithCursor(state: PromptBufferState, isFocused: boolean, placeholder?: string): string {
+export function renderBufferWithCursor(
+  state: PromptBufferState,
+  isFocused: boolean,
+  placeholder?: string,
+  validPastes?: Map<number, string>
+): string {
   const text = state.text || "";
   const cursor = Math.max(0, Math.min(state.cursor, text.length));
+  const validIds = validPastes ?? new Map<number, string>();
 
   if (text.length === 0 && placeholder) {
     if (!isFocused) {
@@ -997,18 +1003,18 @@ export function renderBufferWithCursor(state: PromptBufferState, isFocused: bool
     return renderCursorCell(" ") + chalk.dim(` ${placeholder}`);
   }
 
-  if (!isFocused) {
-    return highlightPasteMarkersInText(text);
+  if (text.length === 0) {
+    return isFocused ? renderCursorCell(" ") : "";
   }
 
-  // Focused: scan through the text, highlight paste markers, and insert
-  // the cursor cell at the correct position. This approach handles the
-  // case where the cursor sits at the start of (or inside) a paste marker.
-  return renderFocusedText(text, cursor);
+  if (!isFocused) {
+    return highlightPasteMarkersInText(text, validIds);
+  }
+
+  return renderFocusedText(text, cursor, validIds);
 }
 
-/** Highlight paste markers in a plain string (no cursor). */
-function highlightPasteMarkersInText(s: string): string {
+function highlightPasteMarkersInText(s: string, validIds: Map<number, string>): string {
   if (!s.includes("[paste #")) return s;
   PASTE_MARKER_REGEX.lastIndex = 0;
   let result = "";
@@ -1016,7 +1022,8 @@ function highlightPasteMarkersInText(s: string): string {
   let match: RegExpExecArray | null;
   while ((match = PASTE_MARKER_REGEX.exec(s)) !== null) {
     result += s.slice(pos, match.index);
-    result += chalk.yellow(match[0]);
+    const id = Number.parseInt(match[1]!, 10);
+    result += validIds.has(id) ? chalk.yellow(match[0]) : match[0];
     pos = match.index + match[0].length;
   }
   result += s.slice(pos);
@@ -1029,7 +1036,7 @@ function highlightPasteMarkersInText(s: string): string {
  * anywhere (including inside or at the boundary of a paste marker) and the
  * marker will still be highlighted correctly.
  */
-function renderFocusedText(text: string, cursor: number): string {
+function renderFocusedText(text: string, cursor: number, validIds: Map<number, string>): string {
   let result = "";
   let pos = 0;
   PASTE_MARKER_REGEX.lastIndex = 0;
@@ -1038,14 +1045,15 @@ function renderFocusedText(text: string, cursor: number): string {
   while ((match = PASTE_MARKER_REGEX.exec(text)) !== null) {
     const markerStart = match.index;
     const markerEnd = match.index + match[0].length;
+    const id = Number.parseInt(match[1]!, 10);
+    const isReal = validIds.has(id);
 
     // 1. Non-marker segment before this marker.
     result += renderTextSegmentWithCursor(text, pos, markerStart, cursor, false);
     pos = markerStart;
 
-    // 2. Marker segment — highlighted with chalk.yellow.
-    //    The cursor may fall inside it.
-    result += renderTextSegmentWithCursor(text, pos, markerEnd, cursor, true);
+    // 2. Marker segment — highlighted only if it corresponds to a real paste.
+    result += renderTextSegmentWithCursor(text, pos, markerEnd, cursor, isReal);
     pos = markerEnd;
   }
 

--- a/src/ui/PromptInput.tsx
+++ b/src/ui/PromptInput.tsx
@@ -4,11 +4,18 @@ import chalk from "chalk";
 import { ARGS_SEPARATOR } from "./constants";
 import {
   EMPTY_BUFFER,
+  PASTE_MARKER_REGEX,
   backspace,
+  cleanPasteContent,
   deleteForward,
+  deletePasteMarkerBackward,
+  deletePasteMarkerForward,
   deleteWordBefore,
   deleteWordAfter,
+  expandPasteMarkers,
+  findPasteMarkerContaining,
   getCurrentSlashToken,
+  hasActivePasteMarkers,
   insertText,
   isEmpty,
   killLine,
@@ -47,7 +54,12 @@ export type { InputKey } from "./prompt";
 
 import { useTerminalInput } from "./prompt";
 import type { InputKey } from "./prompt";
-import { useHiddenTerminalCursor, useTerminalExtendedKeys, useTerminalFocusReporting } from "./prompt";
+import {
+  useHiddenTerminalCursor,
+  useTerminalExtendedKeys,
+  useBracketedPaste,
+  useTerminalFocusReporting,
+} from "./prompt";
 import SlashCommandMenu, { isSkillSelected } from "./SlashCommandMenu";
 import type { ModelConfigSelection } from "../settings";
 import { FileMentionMenu, ModelsDropdown, RawModelDropdown, SkillsDropdown } from "./components";
@@ -143,6 +155,12 @@ export const PromptInput = React.memo(function PromptInput({
   const wasBusyRef = React.useRef(busy);
   const hadFileMentionTokenRef = React.useRef(false);
   const appliedDraftNonceRef = React.useRef<number | null>(null);
+  const pastesRef = React.useRef<Map<number, string>>(new Map());
+  const pasteCounterRef = React.useRef<number>(0);
+  // Track expanded paste regions for toggle (Ctrl+O expand / collapse).
+  const expandedRegionsRef = React.useRef<Map<number, { start: number; end: number; content: string; marker: string }>>(
+    new Map()
+  );
 
   const fileMentionToken = getCurrentFileMentionToken(buffer);
   const hasFileMentionToken = fileMentionToken !== null;
@@ -170,16 +188,25 @@ export const PromptInput = React.memo(function PromptInput({
   const showMenu = slashMenu.length > 0;
   const promptHistoryKey = React.useMemo(() => promptHistory.join("\0"), [promptHistory]);
   const hasRunningProcess = runningProcesses && runningProcesses.size > 0;
-  const processHint = hasRunningProcess ? " · ctrl+o view output" : "";
+  const hasCollapsedMarkers = hasActivePasteMarkers(buffer.text);
+  const hasExpandedRegions = expandedRegionsRef.current.size > 0;
+  const processOrPasteHint = hasRunningProcess
+    ? " · ctrl+o view output"
+    : hasCollapsedMarkers
+      ? " · ctrl+o expand"
+      : hasExpandedRegions
+        ? " · ctrl+o collapse"
+        : "";
   const footerText = statusMessage
     ? statusMessage
     : busy
       ? loadingText && loadingText.trim()
-        ? `${loadingText}${processHint}`
-        : `esc to interrupt · ctrl+c to cancel input${processHint}`
-      : `enter send · shift+enter newline · @ files · ctrl+v image · / commands · ctrl+d exit${processHint}`;
+        ? `${loadingText}${processOrPasteHint}`
+        : `esc to interrupt · ctrl+c to cancel input${processOrPasteHint}`
+      : `enter send · shift+enter newline · @ files · ctrl+v image · / commands · ctrl+d exit${processOrPasteHint}`;
   useTerminalFocusReporting(stdout, !disabled);
   useTerminalExtendedKeys(stdout, !disabled);
+  useBracketedPaste(stdout, !disabled);
   useHiddenTerminalCursor(stdout, !disabled);
 
   const refreshFileMentionItems = React.useCallback(() => {
@@ -241,6 +268,8 @@ export const PromptInput = React.memo(function PromptInput({
     setHistoryCursor(-1);
     setDraftBeforeHistory(null);
     clearPromptUndoRedoState(undoRedoRef.current);
+    pastesRef.current.clear();
+    expandedRegionsRef.current.clear();
   }, [promptDraft]);
 
   useEffect(() => {
@@ -278,7 +307,7 @@ export const PromptInput = React.memo(function PromptInput({
         if (runningProcesses && runningProcesses.size > 0 && onToggleProcessStdout) {
           onToggleProcessStdout();
         } else {
-          setStatusMessage("No running process to inspect");
+          expandPasteMarkerAtCursor();
         }
         return;
       }
@@ -306,6 +335,8 @@ export const PromptInput = React.memo(function PromptInput({
         } else if (!isEmpty(buffer)) {
           setBuffer(EMPTY_BUFFER);
           clearUndoRedoStacks();
+          pastesRef.current.clear();
+          expandedRegionsRef.current.clear();
         } else {
           setStatusMessage("press ctrl+d to exit");
         }
@@ -322,6 +353,11 @@ export const PromptInput = React.memo(function PromptInput({
 
       if (historyCursor !== -1 && !key.upArrow && !key.downArrow) {
         exitHistoryBrowsing();
+      }
+
+      if (key.paste) {
+        handlePaste(input);
+        return;
       }
 
       if (key.ctrl && (input === "v" || input === "V")) {
@@ -395,12 +431,12 @@ export const PromptInput = React.memo(function PromptInput({
       }
 
       if (key.delete) {
-        updateBuffer((s) => deleteForward(s));
+        updateBuffer((s) => deletePasteMarkerForward(s) ?? deleteForward(s));
         return;
       }
 
       if (key.backspace) {
-        updateBuffer((s) => backspace(s));
+        updateBuffer((s) => deletePasteMarkerBackward(s) ?? backspace(s));
         return;
       }
 
@@ -490,6 +526,8 @@ export const PromptInput = React.memo(function PromptInput({
       }
       if (key.ctrl && (input === "u" || input === "U")) {
         updateBuffer(() => EMPTY_BUFFER);
+        pastesRef.current.clear();
+        expandedRegionsRef.current.clear();
         return;
       }
       if (key.ctrl && (input === "w" || input === "W")) {
@@ -567,6 +605,81 @@ export const PromptInput = React.memo(function PromptInput({
     });
   }
 
+  function handlePaste(pastedText: string): void {
+    const totalChars = pastedText.length;
+
+    if (totalChars <= 1000) {
+      const newlineCount = (pastedText.match(/\n/g) ?? []).length;
+      if (newlineCount <= 9) {
+        const clean = pastedText
+          .replace(/\r\n|\r/g, "\n")
+          .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "")
+          .replace(/\t/g, "    ");
+        updateBuffer((s) => insertText(s, clean));
+        return;
+      }
+    }
+
+    // Large paste: store raw text, insert marker with line/char count.
+    const lineCount = (pastedText.match(/\n/g) ?? []).length + 1;
+    pasteCounterRef.current += 1;
+    const pasteId = pasteCounterRef.current;
+    pastesRef.current.set(pasteId, pastedText);
+
+    const marker =
+      lineCount > 10 ? `[paste #${pasteId} +${lineCount} lines]` : `[paste #${pasteId} ${totalChars} chars]`;
+
+    updateBuffer((s) => insertText(s, marker));
+  }
+
+  function expandPasteMarkerAtCursor(): void {
+    // First, try to collapse an already-expanded region at the cursor.
+    for (const [id, region] of expandedRegionsRef.current) {
+      if (buffer.cursor >= region.start && buffer.cursor <= region.end) {
+        // Collapse back to marker.
+        expandedRegionsRef.current.delete(id);
+        pastesRef.current.set(id, region.content);
+        setTimeout(() => {
+          updateBuffer((s) => {
+            const text = s.text.slice(0, region.start) + region.marker + s.text.slice(region.end);
+            return { text, cursor: region.start + region.marker.length };
+          });
+        }, 0);
+        return;
+      }
+    }
+
+    // No expanded region at cursor — try to expand a paste marker.
+    const marker = findPasteMarkerContaining(buffer);
+    if (!marker) {
+      setStatusMessage("No paste marker at cursor");
+      return;
+    }
+    const content = pastesRef.current.get(marker.id);
+    if (!content) {
+      setStatusMessage("Paste content not found");
+      return;
+    }
+
+    const pasteId = marker.id;
+    const originalMarker = buffer.text.slice(marker.start, marker.end);
+    pastesRef.current.delete(pasteId);
+
+    setTimeout(() => {
+      updateBuffer((s) => {
+        const text = s.text.slice(0, marker.start) + cleanPasteContent(content) + s.text.slice(marker.end);
+        const newEnd = marker.start + content.length;
+        expandedRegionsRef.current.set(pasteId, {
+          start: marker.start,
+          end: newEnd,
+          content,
+          marker: originalMarker,
+        });
+        return { text, cursor: marker.start };
+      });
+    }, 0);
+  }
+
   function navigateHistory(direction: -1 | 1): void {
     if (promptHistory.length === 0) {
       return;
@@ -607,6 +720,9 @@ export const PromptInput = React.memo(function PromptInput({
     setImageUrls([]);
     setSelectedSkills([]);
     setShowSkillsDropdown(false);
+    pastesRef.current.clear();
+    expandedRegionsRef.current.clear();
+    pasteCounterRef.current = 0;
   }
 
   function handleSlashSelection(item: SlashCommandItem): void {
@@ -664,6 +780,8 @@ export const PromptInput = React.memo(function PromptInput({
       setImageUrls([]);
       setSelectedSkills([]);
       setShowSkillsDropdown(false);
+      pastesRef.current.clear();
+      expandedRegionsRef.current.clear();
       return;
     }
     if (item.kind === "mcp") {
@@ -699,7 +817,7 @@ export const PromptInput = React.memo(function PromptInput({
     }
 
     onSubmit({
-      text: buffer.text,
+      text: expandPasteMarkers(buffer.text, pastesRef.current),
       imageUrls,
       selectedSkills,
     });
@@ -871,9 +989,6 @@ export function getPromptReturnKeyAction(key: Pick<InputKey, "return" | "shift" 
 export function renderBufferWithCursor(state: PromptBufferState, isFocused: boolean, placeholder?: string): string {
   const text = state.text || "";
   const cursor = Math.max(0, Math.min(state.cursor, text.length));
-  const before = text.slice(0, cursor);
-  const at = text[cursor];
-  const after = text.slice(cursor + 1);
 
   if (text.length === 0 && placeholder) {
     if (!isFocused) {
@@ -883,14 +998,103 @@ export function renderBufferWithCursor(state: PromptBufferState, isFocused: bool
   }
 
   if (!isFocused) {
-    return text.endsWith("\n") ? `${text} ` : text;
+    return highlightPasteMarkersInText(text);
   }
 
-  if (typeof at === "undefined") {
-    return before + renderCursorCell(" ");
+  // Focused: scan through the text, highlight paste markers, and insert
+  // the cursor cell at the correct position. This approach handles the
+  // case where the cursor sits at the start of (or inside) a paste marker.
+  return renderFocusedText(text, cursor);
+}
+
+/** Highlight paste markers in a plain string (no cursor). */
+function highlightPasteMarkersInText(s: string): string {
+  if (!s.includes("[paste #")) return s;
+  PASTE_MARKER_REGEX.lastIndex = 0;
+  let result = "";
+  let pos = 0;
+  let match: RegExpExecArray | null;
+  while ((match = PASTE_MARKER_REGEX.exec(s)) !== null) {
+    result += s.slice(pos, match.index);
+    result += chalk.yellow(match[0]);
+    pos = match.index + match[0].length;
   }
+  result += s.slice(pos);
+  return result.endsWith("\n") ? `${result} ` : result;
+}
+
+/**
+ * Render focused text with paste-marker highlighting and cursor insertion.
+ * Scans through the entire string in one pass, so the cursor can land
+ * anywhere (including inside or at the boundary of a paste marker) and the
+ * marker will still be highlighted correctly.
+ */
+function renderFocusedText(text: string, cursor: number): string {
+  let result = "";
+  let pos = 0;
+  PASTE_MARKER_REGEX.lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = PASTE_MARKER_REGEX.exec(text)) !== null) {
+    const markerStart = match.index;
+    const markerEnd = match.index + match[0].length;
+
+    // 1. Non-marker segment before this marker.
+    result += renderTextSegmentWithCursor(text, pos, markerStart, cursor, false);
+    pos = markerStart;
+
+    // 2. Marker segment — highlighted with chalk.yellow.
+    //    The cursor may fall inside it.
+    result += renderTextSegmentWithCursor(text, pos, markerEnd, cursor, true);
+    pos = markerEnd;
+  }
+
+  // 3. Remainder after the last marker.
+  result += renderTextSegmentWithCursor(text, pos, text.length, cursor, false);
+
+  return result;
+}
+
+/**
+ * Render a segment of `text` from `start` to `end`.
+ * The cursor (if it falls inside this segment) is rendered as an inverse-video cell.
+ */
+function renderTextSegmentWithCursor(
+  text: string,
+  start: number,
+  end: number,
+  cursor: number,
+  highlighted: boolean
+): string {
+  if (start >= end) return "";
+
+  const segText = text.slice(start, end);
+  const cursorRel = cursor - start; // relative cursor position inside this segment
+
+  // Cursor not in this segment – just return the text.
+  if (cursorRel < 0 || cursorRel > segText.length) {
+    return highlighted ? chalk.yellow(segText) : segText;
+  }
+
+  // Cursor is exactly at `end` (which equals `segText.length`).
+  if (cursorRel === segText.length) {
+    return highlighted ? chalk.yellow(segText) + renderCursorCell(" ") : segText + renderCursorCell(" ");
+  }
+
+  // Cursor is somewhere inside the segment.
+  const at = segText[cursorRel];
+
   if (at === "\n") {
+    // Render newline as a space in the cursor cell, then output the actual newline.
+    const before = segText.slice(0, cursorRel);
+    const after = segText.slice(cursorRel + 1);
     return before + renderCursorCell(" ") + "\n" + after;
+  }
+
+  const before = segText.slice(0, cursorRel);
+  const after = segText.slice(cursorRel + 1);
+  if (highlighted) {
+    return chalk.yellow(before) + renderCursorCell(at) + chalk.yellow(after);
   }
   return before + renderCursorCell(at) + after;
 }

--- a/src/ui/prompt/cursor.ts
+++ b/src/ui/prompt/cursor.ts
@@ -40,6 +40,14 @@ function disableTerminalFocusReporting(): string {
   return "\u001B[?1004l";
 }
 
+function enableBracketedPaste(): string {
+  return "\u001B[?2004h";
+}
+
+function disableBracketedPaste(): string {
+  return "\u001B[?2004l";
+}
+
 export function enableTerminalExtendedKeys(): string {
   return "\u001B[>4;1m";
 }
@@ -257,6 +265,19 @@ export function useTerminalExtendedKeys(stdout: NodeJS.WriteStream | undefined, 
     stdout.write(enableTerminalExtendedKeys());
     return () => {
       stdout.write(disableTerminalExtendedKeys());
+    };
+  }, [isActive, stdout]);
+}
+
+export function useBracketedPaste(stdout: NodeJS.WriteStream | undefined, isActive: boolean): void {
+  useLayoutEffect(() => {
+    if (!isActive || !stdout?.isTTY) {
+      return;
+    }
+
+    stdout.write(enableBracketedPaste());
+    return () => {
+      stdout.write(disableBracketedPaste());
     };
   }, [isActive, stdout]);
 }

--- a/src/ui/prompt/index.ts
+++ b/src/ui/prompt/index.ts
@@ -4,6 +4,7 @@ export type { InputKey } from "./useTerminalInput";
 export {
   useHiddenTerminalCursor,
   useTerminalExtendedKeys,
+  useBracketedPaste,
   usePromptTerminalCursor,
   useTerminalFocusReporting,
   getPromptCursorPlacement,

--- a/src/ui/prompt/useTerminalInput.ts
+++ b/src/ui/prompt/useTerminalInput.ts
@@ -20,6 +20,8 @@ export type InputKey = {
   meta: boolean;
   focusIn: boolean;
   focusOut: boolean;
+  /** True when the input came from a bracketed paste (ESC[200~ ... ESC[201~). */
+  paste: boolean;
 };
 
 const BACKSPACE_BYTES = new Set(["\u007F", "\b"]);
@@ -34,6 +36,13 @@ const META_LEFT_SEQUENCES = new Set(["\u001B[1;3D", "\u001B[3D", "\u001Bb"]);
 const META_RIGHT_SEQUENCES = new Set(["\u001B[1;3C", "\u001B[3C", "\u001Bf"]);
 const TERMINAL_FOCUS_IN = "\u001B[I";
 const TERMINAL_FOCUS_OUT = "\u001B[O";
+
+// Bracketed paste mode markers (xterm-style).
+// When the terminal supports bracketed paste, pasted text is wrapped with:
+//   ESC[200~  ...pasted content...  ESC[201~
+const PASTE_START = "\u001B[200~";
+const PASTE_END = "\u001B[201~";
+const PASTE_END_LENGTH = 6; // length of PASTE_END
 
 // Ctrl+- (minus) sequences in modifyOtherKeys mode.
 // \u001B[45;5u  — standard format: keycode=45 ('-'), modifier=5 (Ctrl)
@@ -73,6 +82,7 @@ export function parseTerminalInput(data: Buffer | string): { input: string; key:
       meta: false,
       focusIn: false,
       focusOut: false,
+      paste: false,
     };
     return { input, key };
   }
@@ -100,6 +110,7 @@ export function parseTerminalInput(data: Buffer | string): { input: string; key:
       meta: false,
       focusIn: false,
       focusOut: false,
+      paste: false,
     };
     return { input, key };
   }
@@ -123,6 +134,7 @@ export function parseTerminalInput(data: Buffer | string): { input: string; key:
     meta: META_LEFT_SEQUENCES.has(raw) || META_RIGHT_SEQUENCES.has(raw) || META_RETURN_SEQUENCES.has(raw),
     focusIn: raw === TERMINAL_FOCUS_IN,
     focusOut: raw === TERMINAL_FOCUS_OUT,
+    paste: false,
   };
 
   if (input <= "\u001A" && !key.return) {
@@ -200,6 +212,29 @@ export function dispatchTerminalInput(
   inputHandler(input, key);
 }
 
+/** An InputKey with all fields false (including paste). Used when dispatching paste events. */
+const EMPTY_KEY: InputKey = {
+  upArrow: false,
+  downArrow: false,
+  leftArrow: false,
+  rightArrow: false,
+  home: false,
+  end: false,
+  pageDown: false,
+  pageUp: false,
+  return: false,
+  escape: false,
+  ctrl: false,
+  shift: false,
+  tab: false,
+  backspace: false,
+  delete: false,
+  meta: false,
+  focusIn: false,
+  focusOut: false,
+  paste: false,
+};
+
 export function useTerminalInput(
   inputHandler: (input: string, key: InputKey) => void,
   options: { isActive?: boolean } = {}
@@ -209,8 +244,15 @@ export function useTerminalInput(
   const handlerRef = useRef(inputHandler);
   handlerRef.current = inputHandler;
 
+  // Mutable paste-bracketing state shared across data events.
+  // Uses an array of chunks instead of string concatenation to avoid
+  // O(n²) copying when the terminal splits a large paste across many events.
+  const pasteRef = useRef({ active: false, chunks: [] as string[] });
+
   useEffect(() => {
     if (!isActive) {
+      pasteRef.current.active = false;
+      pasteRef.current.chunks = [];
       return;
     }
     setRawMode(true);
@@ -223,7 +265,75 @@ export function useTerminalInput(
     if (!isActive) {
       return;
     }
+
     const handleData = (data: Buffer | string) => {
+      const raw = String(data);
+
+      // ----- Bracketed paste handling -----
+      // Most terminals send the start/end markers in the same chunk as
+      // the content. We handle both inline and multi-chunk scenarios.
+
+      if (raw.includes(PASTE_START)) {
+        pasteRef.current.active = true;
+        pasteRef.current.chunks = [];
+
+        // Extract content after the start marker.
+        const startIdx = raw.indexOf(PASTE_START);
+        const afterStart = raw.slice(startIdx + PASTE_START.length);
+
+        // Check if the end marker is also in this same chunk.
+        const endIdx = afterStart.indexOf(PASTE_END);
+        if (endIdx !== -1) {
+          // Both markers in one chunk — process immediately.
+          const pasteContent = afterStart.slice(0, endIdx);
+          pasteRef.current.active = false;
+          const remaining = afterStart.slice(endIdx + PASTE_END_LENGTH);
+
+          if (pasteContent.length > 0) {
+            handlerRef.current(pasteContent, { ...EMPTY_KEY, paste: true });
+          }
+          if (remaining.length > 0) {
+            dispatchTerminalInput(remaining, handlerRef.current);
+          }
+          return;
+        }
+
+        // Only start marker — buffer as first chunk.
+        if (afterStart) {
+          pasteRef.current.chunks.push(afterStart);
+        }
+        return;
+      }
+
+      if (pasteRef.current.active) {
+        pasteRef.current.chunks.push(raw);
+        // Only join+search when this chunk might contain the end marker.
+        if (raw.includes("201~")) {
+          const combined = pasteRef.current.chunks.join("");
+          const endIdx = combined.indexOf(PASTE_END);
+          if (endIdx !== -1) {
+            const pasteContent = combined.slice(0, endIdx);
+            pasteRef.current.active = false;
+            const remaining = combined.slice(endIdx + PASTE_END_LENGTH);
+            pasteRef.current.chunks = [];
+
+            // Dispatch the pasted text as a single event.
+            if (pasteContent.length > 0) {
+              handlerRef.current(pasteContent, { ...EMPTY_KEY, paste: true });
+            }
+
+            // Handle any remaining input after the paste end marker.
+            if (remaining.length > 0) {
+              dispatchTerminalInput(remaining, handlerRef.current);
+            }
+            return;
+          }
+          return;
+        }
+        return;
+      }
+
+      // ----- Normal (non-paste) input -----
       dispatchTerminalInput(data, handlerRef.current);
     };
 

--- a/src/ui/promptBuffer.ts
+++ b/src/ui/promptBuffer.ts
@@ -177,7 +177,7 @@ export function getCurrentSlashToken(state: PromptBufferState): string | null {
  * marker is inserted instead of the full content. The actual content is stored in a
  * Map and expanded back before submission.
  */
-export const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+?\d+ lines|\d+ chars))?\]/g;
+export const PASTE_MARKER_REGEX = /\[paste #(\d+) (\+?\d+ lines|\d+ chars)\]/g;
 
 /**
  * Find the paste marker that ends exactly at `state.cursor`, if any.
@@ -214,9 +214,16 @@ export function findPasteMarkerAt(state: PromptBufferState): { start: number; en
  * If the cursor is immediately after a paste marker, delete the entire marker
  * (atomic backspace). Returns the new state, or `state` unchanged if no marker.
  */
-export function deletePasteMarkerBackward(state: PromptBufferState): PromptBufferState | null {
+export function deletePasteMarkerBackward(
+  state: PromptBufferState,
+  validIds: Map<number, unknown>
+): PromptBufferState | null {
   const marker = findPasteMarkerBefore(state);
   if (!marker) return null;
+  // Only delete if this is a real paste marker (ID in validIds).
+  PASTE_MARKER_REGEX.lastIndex = 0;
+  const m = PASTE_MARKER_REGEX.exec(state.text.slice(marker.start, marker.end));
+  if (!m || !validIds.has(Number.parseInt(m[1]!, 10))) return null;
   const text = state.text.slice(0, marker.start) + state.text.slice(marker.end);
   return { text, cursor: marker.start };
 }
@@ -225,9 +232,16 @@ export function deletePasteMarkerBackward(state: PromptBufferState): PromptBuffe
  * If the cursor is at the start of a paste marker, delete the entire marker
  * (atomic forward delete). Returns the new state, or `state` unchanged if no marker.
  */
-export function deletePasteMarkerForward(state: PromptBufferState): PromptBufferState | null {
+export function deletePasteMarkerForward(
+  state: PromptBufferState,
+  validIds: Map<number, unknown>
+): PromptBufferState | null {
   const marker = findPasteMarkerAt(state);
   if (!marker) return null;
+  // Only delete if this is a real paste marker (ID in validIds).
+  PASTE_MARKER_REGEX.lastIndex = 0;
+  const m = PASTE_MARKER_REGEX.exec(state.text.slice(marker.start, marker.end));
+  if (!m || !validIds.has(Number.parseInt(m[1]!, 10))) return null;
   const text = state.text.slice(0, marker.start) + state.text.slice(marker.end);
   return { text, cursor: marker.start };
 }
@@ -252,7 +266,7 @@ export function expandPasteMarkers(text: string, pastes: Map<number, string>): s
   if (pastes.size === 0) return text;
   let result = text;
   for (const [pasteId, pasteContent] of pastes) {
-    const markerRegex = new RegExp(`\\[paste #${pasteId}( (\\+?\\d+ lines|\\d+ chars))?\\]`, "g");
+    const markerRegex = new RegExp(`\\[paste #${pasteId} (\\+?\\d+ lines|\\d+ chars)\\]`, "g");
     result = result.replace(markerRegex, () => cleanPasteContent(pasteContent));
   }
   return result;
@@ -278,11 +292,18 @@ export function findPasteMarkerContaining(state: PromptBufferState): { start: nu
 }
 
 /**
- * Check whether the given text contains any paste markers.
+ * Check whether the text contains real paste markers (IDs present in validIds).
  */
-export function hasActivePasteMarkers(text: string): boolean {
+export function hasActivePasteMarkers(text: string, validIds: Map<number, unknown>): boolean {
+  if (!text.includes("[paste #")) return false;
   PASTE_MARKER_REGEX.lastIndex = 0;
-  return PASTE_MARKER_REGEX.test(text);
+  let match: RegExpExecArray | null;
+  while ((match = PASTE_MARKER_REGEX.exec(text)) !== null) {
+    if (validIds.has(Number.parseInt(match[1]!, 10))) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function locate(state: PromptBufferState): {

--- a/src/ui/promptBuffer.ts
+++ b/src/ui/promptBuffer.ts
@@ -171,6 +171,120 @@ export function getCurrentSlashToken(state: PromptBufferState): string | null {
   return line;
 }
 
+/**
+ * Regex matching paste markers like `[paste #1 +123 lines]` or `[paste #2 1234 chars]`.
+ * When the user pastes a large block of text (>10 lines or >1000 chars), a compact
+ * marker is inserted instead of the full content. The actual content is stored in a
+ * Map and expanded back before submission.
+ */
+export const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+?\d+ lines|\d+ chars))?\]/g;
+
+/**
+ * Find the paste marker that ends exactly at `state.cursor`, if any.
+ * Returns the marker's start and end positions, or `null`.
+ */
+export function findPasteMarkerBefore(state: PromptBufferState): { start: number; end: number } | null {
+  // Walk backwards through all markers and return the one that ends at the cursor.
+  let match: RegExpExecArray | null;
+  PASTE_MARKER_REGEX.lastIndex = 0;
+  while ((match = PASTE_MARKER_REGEX.exec(state.text)) !== null) {
+    if (match.index + match[0].length === state.cursor) {
+      return { start: match.index, end: match.index + match[0].length };
+    }
+  }
+  return null;
+}
+
+/**
+ * Find the paste marker that starts exactly at `state.cursor`, if any.
+ * Returns the marker's start and end positions, or `null`.
+ */
+export function findPasteMarkerAt(state: PromptBufferState): { start: number; end: number } | null {
+  let match: RegExpExecArray | null;
+  PASTE_MARKER_REGEX.lastIndex = 0;
+  while ((match = PASTE_MARKER_REGEX.exec(state.text)) !== null) {
+    if (match.index === state.cursor) {
+      return { start: match.index, end: match.index + match[0].length };
+    }
+  }
+  return null;
+}
+
+/**
+ * If the cursor is immediately after a paste marker, delete the entire marker
+ * (atomic backspace). Returns the new state, or `state` unchanged if no marker.
+ */
+export function deletePasteMarkerBackward(state: PromptBufferState): PromptBufferState | null {
+  const marker = findPasteMarkerBefore(state);
+  if (!marker) return null;
+  const text = state.text.slice(0, marker.start) + state.text.slice(marker.end);
+  return { text, cursor: marker.start };
+}
+
+/**
+ * If the cursor is at the start of a paste marker, delete the entire marker
+ * (atomic forward delete). Returns the new state, or `state` unchanged if no marker.
+ */
+export function deletePasteMarkerForward(state: PromptBufferState): PromptBufferState | null {
+  const marker = findPasteMarkerAt(state);
+  if (!marker) return null;
+  const text = state.text.slice(0, marker.start) + state.text.slice(marker.end);
+  return { text, cursor: marker.start };
+}
+
+/**
+ * Sanitize stored paste content (filter control chars, expand tabs).
+ * Called lazily on expand/submit, not during paste to keep paste instant.
+ */
+export function cleanPasteContent(text: string): string {
+  return text
+    .replace(/\r\n|\r/g, "\n")
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "")
+    .replace(/\t/g, "    ");
+}
+
+/**
+ * Expand paste markers in the text back to their original (cleaned) content.
+ * @param text - Text potentially containing paste markers.
+ * @param pastes - Map of paste ID → original content.
+ */
+export function expandPasteMarkers(text: string, pastes: Map<number, string>): string {
+  if (pastes.size === 0) return text;
+  let result = text;
+  for (const [pasteId, pasteContent] of pastes) {
+    const markerRegex = new RegExp(`\\[paste #${pasteId}( (\\+?\\d+ lines|\\d+ chars))?\\]`, "g");
+    result = result.replace(markerRegex, () => cleanPasteContent(pasteContent));
+  }
+  return result;
+}
+
+/**
+ * Find the paste marker that contains `state.cursor`, if any.
+ * Returns the marker's start, end, and numeric paste ID, or `null`.
+ */
+export function findPasteMarkerContaining(state: PromptBufferState): { start: number; end: number; id: number } | null {
+  let match: RegExpExecArray | null;
+  PASTE_MARKER_REGEX.lastIndex = 0;
+  while ((match = PASTE_MARKER_REGEX.exec(state.text)) !== null) {
+    if (match.index <= state.cursor && match.index + match[0].length >= state.cursor) {
+      return {
+        start: match.index,
+        end: match.index + match[0].length,
+        id: Number.parseInt(match[1]!, 10),
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * Check whether the given text contains any paste markers.
+ */
+export function hasActivePasteMarkers(text: string): boolean {
+  PASTE_MARKER_REGEX.lastIndex = 0;
+  return PASTE_MARKER_REGEX.test(text);
+}
+
 function locate(state: PromptBufferState): {
   line: number;
   column: number;


### PR DESCRIPTION
## Summary

When pasting a large block of text (>10 lines or >1000 characters), the content is replaced with a compact marker like `[paste #1 +63 lines]` instead of inserting the full text.

![paste-marker-demo](https://github.com/user-attachments/assets/d501bffc-8b42-4688-b503-dd8e8f508a4e)

## Features

- **Bracketed paste detection** — Detects `ESC[200~` / `ESC[201~` and dispatches pasted text as a single atomic event
- **Large paste collapsing** — Pastes >10 lines or >1000 chars are stored and replaced with a compact marker
- **Ctrl+O toggle** — Expand to view/edit full content, collapse back to marker (with `setTimeout(0)` to mitigate rendering issues)
- **Atomic deletion** — Backspace/delete on a paste marker removes the entire marker at once
- **Auto-expand on submit** — Markers are expanded to full content before sending to the LLM
- **Yellow highlighting** — Markers are highlighted with `chalk.yellow`
- **Lazy text cleaning** — Control char filtering and line ending normalization are deferred to expand/submit time
- **Array-based chunk buffering** — Uses `chunks[]` instead of string `+=` concatenation to avoid O(n²) on multi-chunk pastes

## Implementation

| File | Changes |
|---|---|
| `src/ui/prompt/useTerminalInput.ts` | Paste bracketing: detection, chunk buffering, same-chunk immediate processing |
| `src/ui/promptBuffer.ts` | `cleanPasteContent`, `expandPasteMarkers`, `findPasteMarkerBefore/At/Containing`, `deletePasteMarkerBackward/Forward`, `hasActivePasteMarkers` |
| `src/ui/prompt/cursor.ts` | `useBracketedPaste` hook (follows existing `useTerminalExtendedKeys` pattern) |
| `src/ui/prompt/index.ts` | Export `useBracketedPaste` |
| `src/ui/PromptInput.tsx` | `handlePaste`, `expandPasteMarkerAtCursor`, rendering with yellow highlight, hint text |

## Verification

```
typecheck  — 0 error
eslint    — 0 error, 0 warning
prettier  — All matched files use Prettier code style
test      — 18/18 prompt buffer tests pass
build     — 414.7kb, successful
```

## Known Limitation

Expand/collapse briefly clears Ink `<Static>` content above the prompt. This is a React render pipeline constraint, not introduced by this PR.

## Reference

- Previous attempt: PR #45 (closed)
- Inspired by pi project's paste marker approach