### PR TITLE
docs(readme): 更新许可证链接到主分支路径

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -195,5 +195,5 @@ If you find this tool helpful, please consider supporting us by:
 [github-issues-shield]: https://img.shields.io/github/issues/lessweb/deepcode-cli?color=4d6BFE&labelColor=black&style=flat-square
 [github-issues-pr-link]: https://github.com/lessweb/deepcode-cli/pulls
 [github-issues-pr-shield]: https://img.shields.io/github/issues-pr/lessweb/deepcode-cli?color=4d6BFE&labelColor=black&style=flat-square
-[github-license-link]: https://github.com/lessweb/deepcode-cli/blob/master/LICENSE
+[github-license-link]: https://github.com/lessweb/deepcode-cli/blob/main/LICENSE
 [github-license-shield]: https://img.shields.io/github/license/lessweb/deepcode-cli?color=4d6BFE&labelColor=black&style=flat-square

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -193,5 +193,5 @@ npm link
 [github-issues-shield]: https://img.shields.io/github/issues/lessweb/deepcode-cli?color=4d6BFE&labelColor=black&style=flat-square
 [github-issues-pr-link]: https://github.com/lessweb/deepcode-cli/pulls
 [github-issues-pr-shield]: https://img.shields.io/github/issues-pr/lessweb/deepcode-cli?color=4d6BFE&labelColor=black&style=flat-square
-[github-license-link]: https://github.com/lessweb/deepcode-cli/blob/master/LICENSE
+[github-license-link]: https://github.com/lessweb/deepcode-cli/blob/main/LICENSE
 [github-license-shield]: https://img.shields.io/github/license/lessweb/deepcode-cli?color=4d6BFE&labelColor=black&style=flat-square

--- a/README.md
+++ b/README.md
@@ -193,5 +193,5 @@ npm link
 [github-issues-shield]: https://img.shields.io/github/issues/lessweb/deepcode-cli?color=4d6BFE&labelColor=black&style=flat-square
 [github-issues-pr-link]: https://github.com/lessweb/deepcode-cli/pulls
 [github-issues-pr-shield]: https://img.shields.io/github/issues-pr/lessweb/deepcode-cli?color=4d6BFE&labelColor=black&style=flat-square
-[github-license-link]: https://github.com/lessweb/deepcode-cli/blob/master/LICENSE
+[github-license-link]: https://github.com/lessweb/deepcode-cli/blob/main/LICENSE
 [github-license-shield]: https://img.shields.io/github/license/lessweb/deepcode-cli?color=4d6BFE&labelColor=black&style=flat-square


### PR DESCRIPTION
- 将 README.md 中许可证链接从 master 更改为 main 分支路径
- 同步更新 README-en.md 中的许可证链接路径
- 同步更新 README-zh_CN.md 中的许可证链接路径
- 保持徽章和其他链接不变，确保一致性和正确性