### PR TITLE
feat(ui): 会话列表支持 Delete 键删除会话

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -1476,6 +1476,28 @@ ${skillMd}
     return index.entries.find((entry) => entry.id === sessionId) ?? null;
   }
 
+  /**
+   * Delete a session by its ID.
+   * Removes the session entry from the index and deletes the associated messages file.
+   * Returns true if the session was found and deleted, false otherwise.
+   */
+  deleteSession(sessionId: string): boolean {
+    const index = this.loadSessionsIndex();
+    const entryIndex = index.entries.findIndex((entry) => entry.id === sessionId);
+    if (entryIndex === -1) {
+      return false;
+    }
+
+    // Remove from index
+    index.entries.splice(entryIndex, 1);
+    this.saveSessionsIndex(index);
+
+    // Remove messages file
+    this.removeSessionMessages([sessionId]);
+
+    return true;
+  }
+
   listSessionMessages(sessionId: string): SessionMessage[] {
     const messagePath = this.getSessionMessagesPath(sessionId);
     if (!fs.existsSync(messagePath)) {

--- a/src/tests/session.test.ts
+++ b/src/tests/session.test.ts
@@ -2123,6 +2123,135 @@ test("SessionManager adjusts the active Bash timeout control and session metadat
   assert.equal(processInfo?.deadlineAt, new Date(timeoutInfo.deadlineAtMs).toISOString());
 });
 
+test("SessionManager.deleteSession removes session entry from the index", () => {
+  const workspace = createTempDir("deepcode-delete-workspace-");
+  const home = createTempDir("deepcode-delete-home-");
+  setHomeDir(home);
+
+  const manager = createSessionManager(workspace, "machine-id-delete");
+  (manager as any).activateSession = async () => {};
+
+  // Create two sessions
+  const session1 = createSessionAndMessages(manager, "session-delete-1", "First session");
+  const session2 = createSessionAndMessages(manager, "session-delete-2", "Second session");
+
+  assert.equal(manager.listSessions().length, 2);
+
+  // Delete the first session
+  const result = manager.deleteSession(session1);
+  assert.equal(result, true);
+
+  const remaining = manager.listSessions();
+  assert.equal(remaining.length, 1);
+  assert.equal(remaining[0]?.id, session2);
+});
+
+test("SessionManager.deleteSession removes the messages file", () => {
+  const workspace = createTempDir("deepcode-delete-msg-workspace-");
+  const home = createTempDir("deepcode-delete-msg-home-");
+  setHomeDir(home);
+
+  const manager = createSessionManager(workspace, "machine-id-delete-msg");
+  (manager as any).activateSession = async () => {};
+
+  const sessionId = createSessionAndMessages(manager, "session-delete-msg", "Test session");
+  const messagePath = path.join(
+    home,
+    ".deepcode",
+    "projects",
+    workspace.replace(/[\\\\/]/g, "-").replace(/:/g, ""),
+    `${sessionId}.jsonl`
+  );
+
+  // Verify messages file exists
+  assert.ok(fs.existsSync(messagePath));
+
+  manager.deleteSession(sessionId);
+
+  // Verify messages file is removed
+  assert.equal(fs.existsSync(messagePath), false);
+});
+
+test("SessionManager.deleteSession returns false when session does not exist", () => {
+  const workspace = createTempDir("deepcode-delete-nonexist-workspace-");
+  const home = createTempDir("deepcode-delete-nonexist-home-");
+  setHomeDir(home);
+
+  const manager = createSessionManager(workspace, "machine-id-delete-nonexist");
+
+  const result = manager.deleteSession("nonexistent-session-id");
+  assert.equal(result, false);
+  assert.equal(manager.listSessions().length, 0);
+});
+
+test("SessionManager.deleteSession does not affect other sessions", () => {
+  const workspace = createTempDir("deepcode-delete-others-workspace-");
+  const home = createTempDir("deepcode-delete-others-home-");
+  setHomeDir(home);
+
+  const manager = createSessionManager(workspace, "machine-id-delete-others");
+  (manager as any).activateSession = async () => {};
+
+  const session1 = createSessionAndMessages(manager, "session-keep-1", "Keep session 1");
+  const session2 = createSessionAndMessages(manager, "session-keep-2", "Keep session 2");
+
+  // Delete non-existent session
+  const result = manager.deleteSession("non-existent");
+  assert.equal(result, false);
+  assert.equal(manager.listSessions().length, 2);
+
+  // Delete one session
+  assert.equal(manager.deleteSession(session1), true);
+  assert.equal(manager.listSessions().length, 1);
+  assert.equal(manager.listSessions()[0]?.id, session2);
+
+  // The remaining session should still have its messages accessible
+  const messages = manager.listSessionMessages(session2);
+  assert.ok(messages.length > 0);
+});
+
+/**
+ * Helper: creates a session and writes a few messages to it so we can test
+ * that deleteSession removes both the index entry and the messages file.
+ */
+function createSessionAndMessages(manager: SessionManager, sessionId: string, summary: string): string {
+  const now = new Date().toISOString();
+  const index = (manager as any).loadSessionsIndex();
+  index.entries.push({
+    id: sessionId,
+    summary,
+    assistantReply: null,
+    assistantThinking: null,
+    assistantRefusal: null,
+    toolCalls: null,
+    status: "completed",
+    failReason: null,
+    usage: null,
+    usagePerModel: null,
+    activeTokens: 0,
+    createTime: now,
+    updateTime: now,
+    processes: null,
+  });
+  (manager as any).saveSessionsIndex(index);
+
+  // Write a couple of message lines to the messages file
+  const projectDir = (manager as any).getProjectStorage().projectDir;
+  const messagePath = path.join(projectDir, `${sessionId}.jsonl`);
+  const msg = JSON.stringify({
+    id: "msg-1",
+    sessionId,
+    role: "user",
+    content: summary,
+    visible: true,
+    createTime: now,
+    updateTime: now,
+  });
+  fs.writeFileSync(messagePath, `${msg}\n`, "utf8");
+
+  return sessionId;
+}
+
 function hasGit(): boolean {
   try {
     execFileSync("git", ["--version"], { stdio: "ignore" });

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -658,6 +658,14 @@ export function App({ projectRoot, initialPrompt, onRestart }: AppProps): React.
           sessions={sessions}
           onSelect={(id) => void handleSelectSession(id)}
           onCancel={() => setView("chat")}
+          onDelete={(id) => {
+            // If the deleted session is the active one, clear it
+            if (sessionManager.getActiveSessionId() === id) {
+              sessionManager.setActiveSessionId(null);
+            }
+            sessionManager.deleteSession(id);
+            refreshSessionsList();
+          }}
         />
       ) : view === "undo" ? (
         <UndoSelector

--- a/src/ui/SessionList.tsx
+++ b/src/ui/SessionList.tsx
@@ -6,6 +6,7 @@ type Props = {
   sessions: SessionEntry[];
   onSelect: (sessionId: string) => void;
   onCancel: () => void;
+  onDelete?: (sessionId: string) => void;
 };
 
 /**
@@ -36,9 +37,10 @@ export function filterSessions(sessions: SessionEntry[], query: string): Session
   });
 }
 
-export function SessionList({ sessions, onSelect, onCancel }: Props): React.ReactElement {
+export function SessionList({ sessions, onSelect, onCancel, onDelete }: Props): React.ReactElement {
   const [index, setIndex] = useState(0);
   const [searchQuery, setSearchQuery] = useState("");
+  const [confirmDeleteSessionId, setConfirmDeleteSessionId] = useState<string | null>(null);
   const { columns, rows } = useWindowSize();
 
   // Filter sessions by search query
@@ -77,7 +79,23 @@ export function SessionList({ sessions, onSelect, onCancel }: Props): React.Reac
     setIndex(0);
   }, []);
 
+  const selectedSession = filteredSessions[safeIndex];
+
   useInput((input, key) => {
+    // If in delete confirmation mode, handle confirm/cancel
+    if (confirmDeleteSessionId) {
+      if (key.return) {
+        onDelete?.(confirmDeleteSessionId);
+        setConfirmDeleteSessionId(null);
+        return;
+      }
+      if (key.escape) {
+        setConfirmDeleteSessionId(null);
+        return;
+      }
+      return;
+    }
+
     // ESC: clear search first, then cancel
     if (key.escape) {
       if (searchQuery) {
@@ -95,13 +113,25 @@ export function SessionList({ sessions, onSelect, onCancel }: Props): React.Reac
       return;
     }
 
-    // Backspace / Delete: remove last search character
-    if (key.backspace || key.delete) {
+    // Backspace: remove last search character
+    if (key.backspace) {
       if (searchQuery) {
         handleBackspace();
         return;
       }
-      // If no search query, navigation keys below handle the rest
+    }
+
+    // Delete key: remove search character, or start delete confirmation
+    if (key.delete) {
+      if (searchQuery) {
+        handleBackspace();
+        return;
+      }
+      // No search query: start delete confirmation if session is selected
+      if (selectedSession && onDelete) {
+        setConfirmDeleteSessionId(selectedSession.id);
+        return;
+      }
     }
 
     // Printable character: append to search query
@@ -211,20 +241,23 @@ export function SessionList({ sessions, onSelect, onCancel }: Props): React.Reac
           ) : (
             visibleSessions.map((session, i) => {
               const actualIndex = scrollOffset + i;
+              const isSelected = actualIndex === safeIndex;
+              const isConfirming = confirmDeleteSessionId === session.id;
               return (
                 <Box key={session.id} height={2} marginBottom={1}>
                   <Box>
-                    <Text color="#229ac3">{actualIndex === safeIndex ? "> " : "  "}</Text>
+                    <Text color="#229ac3">{isSelected ? "> " : "  "}</Text>
                   </Box>
                   <Box flexDirection="column" flexGrow={1}>
                     <Box width={"100%"}>
-                      <Text
-                        {...(actualIndex === safeIndex ? { bold: true } : {})}
-                        color={actualIndex === safeIndex ? "#229ac3" : undefined}
-                      >
+                      <Text {...(isSelected ? { bold: true } : {})} color={isSelected ? "#229ac3" : undefined}>
                         {formatSessionTitle(session.summary || "Untitled")}
                       </Text>
-                      <Text dimColor> ({formatSessionStatus(session.status)})</Text>
+                      {isConfirming ? (
+                        <Text color="yellow"> [Delete? Enter=yes, Esc=no]</Text>
+                      ) : (
+                        <Text dimColor> ({formatSessionStatus(session.status)})</Text>
+                      )}
                     </Box>
                     <Box width="100%">
                       <Text dimColor>{formatTimestamp(session.updateTime)} </Text>
@@ -245,14 +278,28 @@ export function SessionList({ sessions, onSelect, onCancel }: Props): React.Reac
         </Box>
         {/* Footer */}
         <Box flexDirection="column">
-          {hasActiveSearch ? (
+          {confirmDeleteSessionId ? (
+            <Box>
+              <Text color="yellow">Delete this session? </Text>
+              <Text bold color="green">
+                Enter
+              </Text>
+              <Text dimColor> to confirm · </Text>
+              <Text bold color="red">
+                Esc
+              </Text>
+              <Text dimColor> to cancel</Text>
+            </Box>
+          ) : hasActiveSearch ? (
             <Box>
               <Text dimColor>Esc clear search · </Text>
               <Text dimColor>↑/↓ navigate · Enter select · Esc again to cancel</Text>
             </Box>
           ) : (
             <Box>
-              <Text dimColor>Type to search · ↑/↓ navigate · PgUp/PgDn page · Enter select · Esc cancel</Text>
+              <Text dimColor>
+                Type to search · ↑/↓ navigate · PgUp/PgDn page · Enter select · Esc cancel · Del delete
+              </Text>
             </Box>
           )}
         </Box>


### PR DESCRIPTION
### 背景

会话管理列表缺少删除功能，用户无法清理不再需要的会话记录。之前用户只能查看会话列表，无法移除过期或测试用的会话。

### 变更内容

#### 核心逻辑（`src/session.ts`）

新增 `SessionManager.deleteSession(sessionId: string): boolean` 方法：

- 从会话索引文件（`sessions.json`）中移除该会话条目
- 通过已有的 `removeSessionMessages()` 删除对应的 `.jsonl` 消息文件
- 会话不存在时返回 `false`，避免静默失败
- 完整的 JSDoc 类型文档

#### UI 交互（`src/ui/SessionList.tsx`）

新增可选属性 `onDelete?: (sessionId: string) => void`，实现**二级确认机制**防止误删：

1. **Delete 键触发**：非搜索状态下按 `Delete` 键进入删除确认模式
2. **二次确认**：选中的会话旁显示黄色 `[Delete? Enter=yes, Esc=no]` 行内提示
   - `Enter` → 执行删除回调 `onDelete`
   - `Esc` → 取消删除，返回正常导航
3. **底部提示动态切换**：根据状态显示不同的操作指引
   - 正常模式：显示 `Del delete` 快捷键提示
   - 删除确认模式：显示 `Enter to confirm · Esc to cancel`
4. **按键行为分离**：`Backspace` 仅处理搜索输入回删；`Delete` 根据上下文分别处理搜索回删或删除触发

#### 集成（`src/ui/App.tsx`）

`SessionList` 的 `onDelete` 回调处理逻辑：

- 检查被删除的会话是否为当前活跃会话 — 如果是，将 `activeSessionId` 置为 `null`
- 调用 `sessionManager.deleteSession(id)` 执行清理
- 调用 `refreshSessionsList()` 立即刷新 UI

#### 测试（`src/tests/session.test.ts`）

新增 4 个测试用例覆盖所有场景：

| 测试用例 | 描述 | 结果 |
|---------|------|------|
| `deleteSession removes session entry from the index` | 创建 2 个会话，删除 1 个，验证只剩 1 个 | ✅ 通过 |
| `deleteSession removes the messages file` | 创建会话并写入消息，删除后验证 `.jsonl` 文件已不存在 | ✅ 通过 |
| `deleteSession returns false when session does not exist` | 删除不存在的会话 ID，返回 `false`，索引不变 | ✅ 通过 |
| `deleteSession does not affect other sessions` | 从 2 个会话中删除 1 个，剩余会话的消息仍可正常访问 | ✅ 通过 |

### 变更文件统计

```
 src/session.ts            |  22 ++++++++
 src/tests/session.test.ts | 129 ++++++++++++++++++++++++++++++++++++++
 src/ui/App.tsx            |   8 +++
 src/ui/SessionList.tsx    |  71 ++++++++++++++++-----
 4 files changed, 218 insertions(+), 12 deletions(-)
```

### 使用方式

```
1. 打开会话列表
2. 使用 ↑/↓ 导航到目标会话
3. 按 Delete 键 → 出现黄色 "[Delete? Enter=yes, Esc=no]" 确认提示
4. 按 Enter 确认删除，或按 Esc 取消
```

### 全量测试结果

```
ℹ tests 317
ℹ pass  303  ✅（含全部 4 个新增 deleteSession 测试）
ℹ fail  7    ⚠️ 预存环境问题，与本特性无关
ℹ skip  7
```

**预存失败项说明**（与本 PR 无关）：

| 测试用例 | 根因 |
|---------|------|
| `debug logger appends full entries` | 测试环境中文件大小断言不匹配 |
| 4 个 MCP 服务器测试 | Windows `Program Files` 路径含空格导致 MCP 测试脚本启动失败 |
| `Bash timeout control` | 计时敏感断言在 CI 类环境中不稳定 |
| `SessionManager reconnect` | 同上 MCP 路径问题 |

以上 7 个失败均为 **当前 Windows 环境的预存问题**，**非本功能引入**。

### 检查清单

- [x] `npm run typecheck` — 通过
- [x] `npm run lint` — 通过
- [x] `npm run format:check` — 通过
- [x] 全部 4 个新增 `deleteSession` 测试通过
- [x] 7 个预存失败测试无变化（环境相关）
- [x] 使用 Conventional Commit 规范提交
