### PR TITLE
fix(prompt-buffer): 修正 getCurrentSlashToken 函数逻辑

### DIFF
--- a/src/tests/prompt-buffer.test.ts
+++ b/src/tests/prompt-buffer.test.ts
@@ -106,14 +106,14 @@ test("getCurrentSlashToken returns the slash word at the cursor", () => {
   assert.equal(getCurrentSlashToken(buffer), "/skill");
 });
 
-test("getCurrentSlashToken returns null when token contains whitespace", () => {
+test("getCurrentSlashToken returns full text when it starts with /", () => {
   const buffer = { text: "/skill foo", cursor: 10 };
-  assert.equal(getCurrentSlashToken(buffer), null);
+  assert.equal(getCurrentSlashToken(buffer), "/skill foo");
 });
 
-test("getCurrentSlashToken supports slash on a new line", () => {
+test("getCurrentSlashToken returns null when text starts on a new line with /", () => {
   const buffer = { text: "do this\n/n", cursor: 10 };
-  assert.equal(getCurrentSlashToken(buffer), "/n");
+  assert.equal(getCurrentSlashToken(buffer), null);
 });
 
 test("getCurrentSlashToken returns null when no slash prefix", () => {

--- a/src/ui/core/prompt-buffer.ts
+++ b/src/ui/core/prompt-buffer.ts
@@ -155,20 +155,10 @@ export function isEmpty(state: PromptBufferState): boolean {
 
 export function getCurrentSlashToken(state: PromptBufferState): string | null {
   const text = state.text;
-  if (text.length === 0) {
+  if (text.length === 0 || !text.startsWith("/")) {
     return null;
   }
-  const beforeCursor = text.slice(0, state.cursor);
-  const lastNewline = beforeCursor.lastIndexOf("\n");
-  const lineStart = lastNewline + 1;
-  const line = beforeCursor.slice(lineStart);
-  if (!line.startsWith("/")) {
-    return null;
-  }
-  if (/\s/.test(line)) {
-    return null;
-  }
-  return line;
+  return text;
 }
 
 /**


### PR DESCRIPTION
- 优化判断逻辑，只有当文本以斜杠开头时才返回完整文本
- 移除按行处理逻辑，直接返回整个文本
- 修改测试用例以匹配新的行为
- 确保多行文本中不以斜杠开头时返回 null