### PR TITLE
chore(deps): update ink-gradient to 4.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "gray-matter": "^4.0.3",
         "ignore": "^7.0.5",
         "ink": "^7.0.4",
-        "ink-gradient": "^4.0.0",
+        "ink-gradient": "^4.0.1",
         "openai": "^6.35.0",
         "react": "^19.2.5",
         "undici": "^7.25.0",
@@ -2503,9 +2503,9 @@
       }
     },
     "node_modules/ink-gradient": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmmirror.com/ink-gradient/-/ink-gradient-4.0.0.tgz",
-      "integrity": "sha512-Yx227CStr4DaXVkRAQPbBufSUTqe4a4FLOPVoypXZyae5h3A5jWyqZpTmAIbm7iiiqNYCkKIFBUPJM6nSICfxA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmmirror.com/ink-gradient/-/ink-gradient-4.0.1.tgz",
+      "integrity": "sha512-0ckdiM84zkfCdnTtcnq4BS3egIhUPPDoCqSx/7NUFsAVooBbdRuGnnWpk0fuaOTqU6rlZRh9F4LN1UI8fxd81Q==",
       "license": "MIT",
       "dependencies": {
         "@types/gradient-string": "^1.1.6",
@@ -2519,7 +2519,8 @@
         "url": "https://github.com/sponsors/sindresorhus"
       },
       "peerDependencies": {
-        "ink": ">=6"
+        "ink": ">=6",
+        "react": ">=19.2.0"
       }
     },
     "node_modules/is-extendable": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "gray-matter": "^4.0.3",
     "ignore": "^7.0.5",
     "ink": "^7.0.4",
-    "ink-gradient": "^4.0.0",
+    "ink-gradient": "^4.0.1",
     "openai": "^6.35.0",
     "react": "^19.2.5",
     "undici": "^7.25.0",


### PR DESCRIPTION
将 ink-gradient 更新到 `^4.0.1`。

此前的 ink-gradient 没有把 `react` 加入 `peerDependencies`，导致使用 pnpm v11 以上版本安装后，deepcode 无法启动并报错：

```text
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'react' imported from .../ink-gradient/dist/index.js
```

4.0.1 版本修复了这个问题，见 [Release v4.0.1 · sindresorhus/ink-gradient
](https://github.com/sindresorhus/ink-gradient/releases/tag/v4.0.1) https://github.com/sindresorhus/ink-gradient/pull/8

build 和 pack 通过，可以启动。