### PR TITLE
chore: 更新API Key not found时的文本显示

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -1185,13 +1185,13 @@ ${skillMd}
       this.updateSessionEntry(sessionId, (entry) => ({
         ...entry,
         status: "failed",
-        failReason: "OpenAI API key not found",
+        failReason: "API key not found",
         updateTime: now,
       }));
       this.onAssistantMessage(
         this.buildAssistantMessage(
           sessionId,
-          "OpenAI API key not found. Please configure ~/.deepcode/settings.json or ./.deepcode/settings.json.",
+          "API key not found. Please configure ~/.deepcode/settings.json or ./.deepcode/settings.json.",
           null
         ),
         false


### PR DESCRIPTION
新用户第一次使用时，显示Model是deepseek-v4-pro，但是提示OpenAI API key不存在，会引起歧义，去掉OpenAI标识，避免误会。
<img width="721" height="563" alt="Clipboard_Screenshot_1780124465" src="https://github.com/user-attachments/assets/2349b0e0-29be-4189-b21f-d7582c94cf90" />
