### PR TITLE
feat: session name can be edited now

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -1671,6 +1671,27 @@ ${skillMd}
     return true;
   }
 
+  /**
+   * Rename a session by updating its summary (display title).
+   * Returns true if the session was found and renamed, false otherwise.
+   */
+  renameSession(sessionId: string, summary: string): boolean {
+    const trimmed = summary.trim();
+    if (!trimmed) {
+      return false;
+    }
+    const entry = this.getSession(sessionId);
+    if (!entry) {
+      return false;
+    }
+    this.updateSessionEntry(sessionId, (existing) => ({
+      ...existing,
+      summary: trimmed,
+      updateTime: new Date().toISOString(),
+    }));
+    return true;
+  }
+
   listSessionMessages(sessionId: string): SessionMessage[] {
     const messagePath = this.getSessionMessagesPath(sessionId);
     if (!fs.existsSync(messagePath)) {

--- a/src/ui/views/App.tsx
+++ b/src/ui/views/App.tsx
@@ -751,6 +751,14 @@ function App({ projectRoot, initialPrompt, onRestart }: AppProps): React.ReactEl
           onDelete={(id) => {
             void handleDeleteSession(id);
           }}
+          onRename={(id, newName) => {
+            if (sessionManager.renameSession(id, newName)) {
+              refreshSessionsList();
+              setStatusLine(`Session renamed to "${newName}".`);
+            } else {
+              setErrorLine("Failed to rename session.");
+            }
+          }}
         />
       ) : view === "undo" ? (
         <UndoSelector

--- a/src/ui/views/SessionList.tsx
+++ b/src/ui/views/SessionList.tsx
@@ -8,6 +8,7 @@ type Props = {
   onSelect: (sessionId: string) => void;
   onCancel: () => void;
   onDelete?: (sessionId: string) => void;
+  onRename?: (sessionId: string, newName: string) => void;
 };
 
 /**
@@ -38,10 +39,13 @@ export function filterSessions(sessions: SessionEntry[], query: string): Session
   });
 }
 
-export function SessionList({ sessions, onSelect, onCancel, onDelete }: Props): React.ReactElement {
+export function SessionList({ sessions, onSelect, onCancel, onDelete, onRename }: Props): React.ReactElement {
   const [index, setIndex] = useState(0);
   const [searchQuery, setSearchQuery] = useState("");
   const [confirmDeleteSessionId, setConfirmDeleteSessionId] = useState<string | null>(null);
+  const [renameSessionId, setRenameSessionId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState("");
+  const [renameCursor, setRenameCursor] = useState(0);
   const { columns, rows } = useWindowSize();
 
   // Filter sessions by search query
@@ -83,6 +87,65 @@ export function SessionList({ sessions, onSelect, onCancel, onDelete }: Props): 
   const selectedSession = filteredSessions[safeIndex];
 
   useInput((input, key) => {
+    // If in rename mode, handle rename editing
+    if (renameSessionId) {
+      if (key.return) {
+        if (renameValue.trim()) {
+          onRename?.(renameSessionId, renameValue.trim());
+        }
+        setRenameSessionId(null);
+        setRenameValue("");
+        setRenameCursor(0);
+        return;
+      }
+      if (key.escape) {
+        setRenameSessionId(null);
+        setRenameValue("");
+        setRenameCursor(0);
+        return;
+      }
+      if (key.leftArrow) {
+        setRenameCursor((c) => Math.max(0, c - 1));
+        return;
+      }
+      if (key.rightArrow) {
+        setRenameCursor((c) => Math.min(renameValue.length, c + 1));
+        return;
+      }
+      if (key.home) {
+        setRenameCursor(0);
+        return;
+      }
+      if (key.end) {
+        setRenameCursor(renameValue.length);
+        return;
+      }
+      if (key.delete) {
+        if (renameCursor < renameValue.length) {
+          setRenameValue((prev) => prev.slice(0, renameCursor) + prev.slice(renameCursor + 1));
+          // cursor stays at same position (next char shifts left)
+        }
+        return;
+      }
+      if (key.backspace) {
+        if (renameCursor > 0) {
+          setRenameValue((prev) => prev.slice(0, renameCursor - 1) + prev.slice(renameCursor));
+          setRenameCursor((c) => c - 1);
+        }
+        return;
+      }
+      // Printable character: insert at cursor position
+      if (input && input.length > 0 && !key.meta && !key.ctrl && !key.tab) {
+        if (key.upArrow || key.downArrow) {
+          return;
+        }
+        setRenameValue((prev) => prev.slice(0, renameCursor) + input + prev.slice(renameCursor));
+        setRenameCursor((c) => c + input.length);
+        return;
+      }
+      return;
+    }
+
     // If in delete confirmation mode, handle confirm/cancel
     if (confirmDeleteSessionId) {
       if (key.return) {
@@ -112,6 +175,17 @@ export function SessionList({ sessions, onSelect, onCancel, onDelete }: Props): 
     if (key.ctrl && (input === "c" || input === "C")) {
       onCancel();
       return;
+    }
+
+    // Ctrl+R: start rename on selected session
+    if (key.ctrl && (input === "r" || input === "R")) {
+      if (selectedSession && onRename) {
+        const name = selectedSession.summary || "";
+        setRenameSessionId(selectedSession.id);
+        setRenameValue(name);
+        setRenameCursor(name.length);
+        return;
+      }
     }
 
     // Delete key: remove search character, or start delete confirmation
@@ -237,6 +311,7 @@ export function SessionList({ sessions, onSelect, onCancel, onDelete }: Props): 
               const actualIndex = scrollOffset + i;
               const isSelected = actualIndex === safeIndex;
               const isConfirming = confirmDeleteSessionId === session.id;
+              const isRenaming = renameSessionId === session.id;
               return (
                 <Box key={session.id} height={2} marginBottom={1}>
                   <Box>
@@ -244,12 +319,20 @@ export function SessionList({ sessions, onSelect, onCancel, onDelete }: Props): 
                   </Box>
                   <Box flexDirection="column" flexGrow={1}>
                     <Box width={"100%"}>
-                      <Text {...(isSelected ? { bold: true } : {})} color={isSelected ? "#229ac3" : undefined}>
-                        {formatSessionTitle(session.summary || "Untitled")}
-                      </Text>
+                      {isRenaming ? (
+                        <Text color="yellow">
+                          Rename: {renameValue.slice(0, renameCursor)}
+                          <Text bold>|</Text>
+                          {renameValue.slice(renameCursor)}
+                        </Text>
+                      ) : (
+                        <Text {...(isSelected ? { bold: true } : {})} color={isSelected ? "#229ac3" : undefined}>
+                          {formatSessionTitle(session.summary || "Untitled")}
+                        </Text>
+                      )}
                       {isConfirming ? (
                         <Text color="yellow"> [Delete? Enter=yes, Esc=no]</Text>
-                      ) : (
+                      ) : isRenaming ? null : (
                         <Text dimColor> ({formatSessionStatus(session.status)})</Text>
                       )}
                     </Box>
@@ -272,7 +355,19 @@ export function SessionList({ sessions, onSelect, onCancel, onDelete }: Props): 
         </Box>
         {/* Footer */}
         <Box flexDirection="column">
-          {confirmDeleteSessionId ? (
+          {renameSessionId ? (
+            <Box>
+              <Text color="yellow">Input new session name, </Text>
+              <Text bold color="green">
+                Enter
+              </Text>
+              <Text dimColor> to save · </Text>
+              <Text bold color="red">
+                Esc
+              </Text>
+              <Text dimColor> to cancel</Text>
+            </Box>
+          ) : confirmDeleteSessionId ? (
             <Box>
               <Text color="yellow">Delete this session? </Text>
               <Text bold color="green">
@@ -292,7 +387,7 @@ export function SessionList({ sessions, onSelect, onCancel, onDelete }: Props): 
           ) : (
             <Box>
               <Text dimColor>
-                Type to search · ↑/↓ navigate · PgUp/PgDn page · Enter select · Esc cancel · Del delete
+                Type to search · ↑/↓ navigate · PgUp/PgDn page · Enter select · Esc cancel · Del delete · Ctrl+r rename
               </Text>
             </Box>
           )}


### PR DESCRIPTION
支持会话名称，重命名，便于管理和review会话。
包括会话列表页面，右下角添加rename快捷键提示
<img width="2346" height="1254" alt="image" src="https://github.com/user-attachments/assets/da39dd88-b459-4463-b527-f477f068f6e9" />

重命名操作界面
<img width="2349" height="1287" alt="image" src="https://github.com/user-attachments/assets/88b0c250-177f-4a94-b48b-df62ea0285da" />

已通过npm test、npm run check、npm run format