### PR TITLE
修复提示输入的换行、光标定位与 busy 状态显示

### DIFF
--- a/src/tests/message-view.test.ts
+++ b/src/tests/message-view.test.ts
@@ -1,6 +1,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import React from "react";
+import { renderToString } from "ink";
 import { parseDiffPreview } from "../ui";
+import { MessageView, getPromptEchoContentWidth } from "../ui/components/MessageView";
 import {
   buildThinkingSummary,
   formatBashStatusParams,
@@ -117,6 +120,26 @@ test("renderMessageToStdout shows (no content) for empty user messages", () => {
   const msg = makeSessionMessage({ role: "user", content: "" });
   const output = renderMessageToStdout(msg, RawMode.Raw);
   assert.ok(output.includes("(no content)"));
+});
+
+test("MessageView echoes submitted user prompts with live prompt wrapping width", () => {
+  assert.equal(getPromptEchoContentWidth(8), 6);
+
+  const msg = makeSessionMessage({ role: "user", content: "abcdefg" });
+  const output = renderToString(React.createElement(MessageView, { message: msg, width: 8 }), { columns: 8 });
+
+  assert.equal(output, "> abcdef\n  g\n");
+});
+
+test("MessageView echoes model changes with submitted prompt wrapping", () => {
+  const msg = makeSessionMessage({
+    role: "system",
+    content: "abcdefgh",
+    meta: { isModelChange: true },
+  });
+  const output = renderToString(React.createElement(MessageView, { message: msg, width: 8 }), { columns: 8 });
+
+  assert.equal(output, "> abcdef\n  gh\n");
 });
 
 test("renderMessageToStdout renders assistant non-thinking messages with ✦", () => {

--- a/src/tests/prompt-input-keys.test.ts
+++ b/src/tests/prompt-input-keys.test.ts
@@ -13,8 +13,10 @@ import {
   formatSelectedSkillsStatus,
   getPromptCursorPlacement,
   getPromptReturnKeyAction,
+  isPromptCursorAtWrapBoundary,
   isClearImageAttachmentsShortcut,
   removeCurrentSlashToken,
+  resolvePromptTerminalCursorPosition,
   toggleSkillSelection,
   renderBufferWithCursor,
   buildInitPromptSubmission,
@@ -294,24 +296,83 @@ test("renderBufferWithCursor styles exactly one simulated cursor", () => {
   assert.equal((renderBufferWithCursor({ text: "hello\nworld", cursor: 6 }, true).match(ANSI_RE) ?? []).length, 2);
 });
 
-test("getPromptCursorPlacement targets the prompt row above divider and footer", () => {
-  const placement = getPromptCursorPlacement({ text: "hello", cursor: 5 }, 80, 2, "Enter send");
-  assert.deepEqual(placement, { rowsUp: 3, column: 7 });
+test("renderBufferWithCursor can suppress the simulated cursor for real terminal cursor mode", () => {
+  assert.equal(
+    (renderBufferWithCursor({ text: "", cursor: 0 }, true, undefined, undefined, false).match(ANSI_RE) ?? []).length,
+    0
+  );
+  assert.equal(
+    stripAnsi(renderBufferWithCursor({ text: "", cursor: 0 }, true, "Ask anything", undefined, false)),
+    "  Ask anything"
+  );
+  assert.equal(
+    (renderBufferWithCursor({ text: "hello", cursor: 1 }, true, undefined, undefined, false).match(ANSI_RE) ?? [])
+      .length,
+    0
+  );
+  assert.equal(
+    stripAnsi(renderBufferWithCursor({ text: "hello\n", cursor: 6 }, true, undefined, undefined, false)),
+    "hello\n "
+  );
+});
+
+test("getPromptCursorPlacement targets an Ink-relative prompt cell", () => {
+  const placement = getPromptCursorPlacement({ text: "hello", cursor: 5 }, 80);
+  assert.deepEqual(placement, { row: 0, column: 5 });
 });
 
 test("getPromptCursorPlacement targets the reserved row after a trailing newline", () => {
-  const placement = getPromptCursorPlacement({ text: "hello\n", cursor: 6 }, 80, 2, "Enter send");
-  assert.deepEqual(placement, { rowsUp: 3, column: 2 });
+  const placement = getPromptCursorPlacement({ text: "hello\n", cursor: 6 }, 80);
+  assert.deepEqual(placement, { row: 1, column: 0 });
 });
 
 test("getPromptCursorPlacement accounts for CJK character width", () => {
-  const placement = getPromptCursorPlacement({ text: "你好", cursor: 2 }, 80, 2, "Enter send");
-  assert.equal(placement.column, 6);
+  const placement = getPromptCursorPlacement({ text: "你好", cursor: 2 }, 80);
+  assert.equal(placement.column, 4);
 });
 
 test("getPromptCursorPlacement accounts for multiline buffer rows", () => {
-  const placement = getPromptCursorPlacement({ text: "hello\nworld", cursor: 11 }, 80, 2, "Enter send");
-  assert.deepEqual(placement, { rowsUp: 3, column: 7 });
-  const middle = getPromptCursorPlacement({ text: "hello\nworld", cursor: 2 }, 80, 2, "Enter send");
-  assert.deepEqual(middle, { rowsUp: 4, column: 4 });
+  const placement = getPromptCursorPlacement({ text: "hello\nworld", cursor: 11 }, 80);
+  assert.deepEqual(placement, { row: 1, column: 5 });
+  const middle = getPromptCursorPlacement({ text: "hello\nworld", cursor: 2 }, 80);
+  assert.deepEqual(middle, { row: 0, column: 2 });
+});
+
+test("getPromptCursorPlacement accounts for wrapped input rows", () => {
+  const placement = getPromptCursorPlacement({ text: "hello", cursor: 5 }, 5);
+  assert.deepEqual(placement, { row: 1, column: 0 });
+  const cursorBeforeWrappedChar = getPromptCursorPlacement({ text: "hello!", cursor: 5 }, 5);
+  assert.deepEqual(cursorBeforeWrappedChar, { row: 1, column: 0 });
+  const secondLine = getPromptCursorPlacement({ text: "hello!", cursor: 6 }, 5);
+  assert.deepEqual(secondLine, { row: 1, column: 1 });
+});
+
+test("isPromptCursorAtWrapBoundary detects hard-wrapped cursor positions", () => {
+  assert.equal(isPromptCursorAtWrapBoundary({ text: "hell", cursor: 4 }, 5), false);
+  assert.equal(isPromptCursorAtWrapBoundary({ text: "hello", cursor: 5 }, 5), true);
+  assert.equal(isPromptCursorAtWrapBoundary({ text: "hello!", cursor: 6 }, 5), true);
+  assert.equal(isPromptCursorAtWrapBoundary({ text: "hello world", cursor: 6 }, 5), true);
+  assert.equal(isPromptCursorAtWrapBoundary({ text: "hello\n", cursor: 6 }, 5), false);
+  assert.equal(isPromptCursorAtWrapBoundary({ text: "hello\nworld", cursor: 11 }, 5), true);
+});
+
+test("resolvePromptTerminalCursorPosition requires matching measured layout", () => {
+  const placement = { row: 1, column: 4 };
+  const origin = { layoutKey: "skills:1", left: 2, top: 3 };
+
+  assert.deepEqual(resolvePromptTerminalCursorPosition(placement, true, "skills:1", origin), { x: 6, y: 4 });
+  assert.equal(resolvePromptTerminalCursorPosition(placement, true, "skills:0", origin), undefined);
+  assert.equal(resolvePromptTerminalCursorPosition(placement, false, "skills:1", origin), undefined);
+  assert.equal(resolvePromptTerminalCursorPosition(placement, true, "skills:1", null), undefined);
+});
+
+test("resolvePromptTerminalCursorPosition clamps negative terminal cells", () => {
+  assert.deepEqual(
+    resolvePromptTerminalCursorPosition({ row: 0, column: 1 }, true, "current", {
+      layoutKey: "current",
+      left: -5,
+      top: -1,
+    }),
+    { x: 0, y: 0 }
+  );
 });

--- a/src/ui/components/MessageView/index.tsx
+++ b/src/ui/components/MessageView/index.tsx
@@ -12,6 +12,8 @@ import {
 import type { DiffPreviewLine, MessageViewProps } from "./types";
 import { RawMode, useRawModeContext } from "../../contexts";
 
+const PROMPT_ECHO_PREFIX_WIDTH = 2;
+
 export function MessageView({ message, collapsed, width = 80 }: MessageViewProps): React.ReactElement | null {
   const { mode } = useRawModeContext();
   if (!message.visible) {
@@ -21,17 +23,11 @@ export function MessageView({ message, collapsed, width = 80 }: MessageViewProps
   if (message.role === "user") {
     const text = message.content || "(no content)";
     return (
-      <Box marginLeft={1} marginBottom={1} flexDirection="row" marginY={0} flexGrow={1} gap={1}>
-        <Box>
-          <Text color="#229ac3">{`>`}</Text>
-        </Box>
-        <Box flexGrow={1}>
-          <Text color="#229ac3">{text}</Text>
-          {Array.isArray(message.contentParams) && message.contentParams.length > 0 ? (
-            <Text color="#229ac3">{`  📎 ${message.contentParams.length} image attachment(s)`}</Text>
-          ) : null}
-        </Box>
-      </Box>
+      <PromptEchoLine
+        text={text}
+        width={width}
+        attachmentCount={Array.isArray(message.contentParams) ? message.contentParams.length : 0}
+      />
     );
   }
 
@@ -109,16 +105,7 @@ export function MessageView({ message, collapsed, width = 80 }: MessageViewProps
   if (message.role === "system") {
     // Render model change messages in the same style as user commands.
     if (message.meta?.isModelChange) {
-      return (
-        <Box marginY={0} marginLeft={1} marginBottom={1} flexGrow={1} flexDirection="row" gap={1}>
-          <Box>
-            <Text color="#229ac3">{`>`}</Text>
-          </Box>
-          <Box flexGrow={1} flexDirection="column">
-            <Text color="#229ac3">{message.content}</Text>
-          </Box>
-        </Box>
-      );
+      return <PromptEchoLine text={message.content || ""} width={width} />;
     }
 
     if (message.meta?.skill) {
@@ -141,6 +128,35 @@ export function MessageView({ message, collapsed, width = 80 }: MessageViewProps
   }
 
   return null;
+}
+
+export function getPromptEchoContentWidth(width: number): number {
+  return Math.max(1, width - PROMPT_ECHO_PREFIX_WIDTH);
+}
+
+function PromptEchoLine({
+  text,
+  width,
+  attachmentCount = 0,
+}: {
+  text: string;
+  width: number;
+  attachmentCount?: number;
+}): React.ReactElement {
+  const contentWidth = getPromptEchoContentWidth(width);
+  return (
+    <Box marginBottom={1} marginY={0} width={Math.max(1, width)} flexDirection="row">
+      <Box width={PROMPT_ECHO_PREFIX_WIDTH}>
+        <Text color="#229ac3">{"> "}</Text>
+      </Box>
+      <Box flexGrow={1} flexShrink={1} width={contentWidth}>
+        <Text color="#229ac3" wrap="hard">
+          {text}
+        </Text>
+        {attachmentCount > 0 ? <Text color="#229ac3">{`  📎 ${attachmentCount} image attachment(s)`}</Text> : null}
+      </Box>
+    </Box>
+  );
 }
 
 function StatusLine({

--- a/src/ui/hooks/cursor.ts
+++ b/src/ui/hooks/cursor.ts
@@ -1,28 +1,19 @@
-import { useLayoutEffect, useRef } from "react";
+import { useCursor, useBoxMetrics } from "ink";
+import { useLayoutEffect, useState } from "react";
+import type { RefObject } from "react";
+import type { DOMElement } from "ink";
 import type { PromptBufferState } from "../core/prompt-buffer";
 
-type CursorPlacement = {
-  rowsUp: number;
+export type CursorPlacement = {
+  row: number;
   column: number;
 };
 
-type WriteFn = (
-  chunk: string | Uint8Array,
-  encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
-  callback?: (error?: Error | null) => void
-) => boolean;
-
-function cursorUp(rows: number): string {
-  return rows > 0 ? `\u001B[${rows}A` : "";
-}
-
-function cursorDown(rows: number): string {
-  return rows > 0 ? `\u001B[${rows}B` : "";
-}
-
-function cursorForward(columns: number): string {
-  return columns > 0 ? `\u001B[${columns}C` : "";
-}
+export type PromptCursorOrigin = {
+  layoutKey: string;
+  left: number;
+  top: number;
+};
 
 function showCursor(): string {
   return "\u001B[?25h";
@@ -59,42 +50,40 @@ export function disableTerminalExtendedKeys(): string {
 export function getPromptCursorPlacement(
   state: PromptBufferState,
   screenWidth: number,
-  prefixWidth: number,
-  footerText: string
+  initialColumn = 0
 ): CursorPlacement {
   const width = Math.max(1, screenWidth);
   const cursor = Math.max(0, Math.min(state.cursor, state.text.length));
   const beforeCursor = state.text.slice(0, cursor);
-  const at = state.text[cursor];
-  const displayText =
-    beforeCursor +
-    (typeof at === "undefined" || at === "\n" ? " " : at) +
-    (at === "\n" ? "\n" : "") +
-    (typeof at === "undefined" ? "" : state.text.slice(cursor + 1));
-
-  const cursorPosition = measureTextPosition(beforeCursor, width, prefixWidth);
-  const promptRows = measureTextRows(displayText, width, prefixWidth);
-  const footerRows = 1 + measureTextRows(footerText, width, 0);
-
-  return {
-    rowsUp: promptRows - 1 - cursorPosition.row + footerRows + 1,
-    column: cursorPosition.column,
-  };
+  const cursorPosition = measureTextPosition(beforeCursor, width, initialColumn);
+  return { row: cursorPosition.row, column: cursorPosition.column };
 }
 
-function measureTextRows(text: string, width: number, initialColumn: number): number {
-  return measureTextPosition(text, width, initialColumn).row + 1;
+export function isPromptCursorAtWrapBoundary(state: PromptBufferState, screenWidth: number): boolean {
+  const width = Math.max(1, screenWidth);
+  const cursor = Math.max(0, Math.min(state.cursor, state.text.length));
+  const currentLineStart = state.text.lastIndexOf("\n", Math.max(0, cursor - 1)) + 1;
+  const currentLineBeforeCursor = state.text.slice(currentLineStart, cursor);
+  return measureTextPosition(currentLineBeforeCursor, width, 0).row > 0;
 }
 
 function measureTextPosition(text: string, width: number, initialColumn: number): { row: number; column: number } {
   let row = 0;
   let column = Math.min(initialColumn, width - 1);
+  let pendingWrap = false;
 
   for (const char of Array.from(text)) {
     if (char === "\n") {
       row++;
       column = Math.min(initialColumn, width - 1);
+      pendingWrap = false;
       continue;
+    }
+
+    if (pendingWrap) {
+      row++;
+      column = Math.min(initialColumn, width - 1);
+      pendingWrap = false;
     }
 
     const charColumns = textWidth(char);
@@ -104,9 +93,13 @@ function measureTextPosition(text: string, width: number, initialColumn: number)
     }
     column += charColumns;
     if (column >= width) {
-      row++;
-      column = Math.min(initialColumn, width - 1);
+      column = width;
+      pendingWrap = true;
     }
+  }
+
+  if (pendingWrap) {
+    return { row: row + 1, column: Math.min(initialColumn, width - 1) };
   }
 
   return { row, column };
@@ -144,90 +137,79 @@ function characterWidth(char: string): number {
 }
 
 export function usePromptTerminalCursor(
-  stdout: NodeJS.WriteStream | undefined,
+  targetRef: RefObject<DOMElement | null>,
   placement: CursorPlacement,
-  isActive: boolean
-): void {
-  const directWriteRef = useRef<((data: string) => void) | null>(null);
-  const activePlacementRef = useRef<CursorPlacement | null>(null);
-  const lastPlacementRef = useRef<CursorPlacement | null>(null);
-  const unmountingRef = useRef(false);
+  isActive: boolean,
+  layoutKey = "default"
+): boolean {
+  const { setCursorPosition } = useCursor();
+  const metrics = useBoxMetrics(targetRef as RefObject<DOMElement>);
+  const [origin, setOrigin] = useState<PromptCursorOrigin | null>(null);
 
   useLayoutEffect(() => {
-    if (!stdout?.isTTY) {
+    if (!isActive || !metrics.hasMeasured) {
       return;
     }
 
-    const stream = stdout as NodeJS.WriteStream & { write: WriteFn };
-    const originalWrite = stream.write;
-    const directWrite = (data: string) => {
-      originalWrite.call(stdout, data);
-    };
-    const restorePromptCursor = () => {
-      if (unmountingRef.current) {
-        return;
+    const absolutePosition = getAbsoluteElementPosition(targetRef.current);
+    setOrigin((previous) => {
+      if (!absolutePosition) {
+        return previous === null ? previous : null;
       }
-      const activePlacement = activePlacementRef.current;
-      if (!activePlacement) {
-        return;
+
+      if (
+        previous?.layoutKey === layoutKey &&
+        previous.left === absolutePosition.left &&
+        previous.top === absolutePosition.top
+      ) {
+        return previous;
       }
-      directWrite("\r" + cursorDown(activePlacement.rowsUp) + hideCursor());
-      activePlacementRef.current = null;
-      // Schedule a deferred re-position in case the layout effect does not
-      // re-run (e.g. a dropdown closed without changing the buffer).
-      Promise.resolve().then(() => {
-        if (unmountingRef.current || activePlacementRef.current) {
-          return;
-        }
-        const latest = directWriteRef.current;
-        const p = lastPlacementRef.current;
-        if (latest && p) {
-          latest(showCursor() + cursorUp(p.rowsUp) + "\r" + cursorForward(p.column));
-          activePlacementRef.current = p;
-        }
-      });
-    };
-    const patchedWrite: WriteFn = (...args) => {
-      restorePromptCursor();
-      return originalWrite.apply(stdout, args);
-    };
 
-    directWriteRef.current = directWrite;
-    stream.write = patchedWrite;
+      return {
+        layoutKey,
+        left: absolutePosition.left,
+        top: absolutePosition.top,
+      };
+    });
+  }, [isActive, layoutKey, metrics.hasMeasured, metrics.height, metrics.left, metrics.top, metrics.width, targetRef]);
 
-    return () => {
-      restorePromptCursor();
-      stream.write = originalWrite;
-      directWriteRef.current = null;
-    };
-  }, [stdout]);
+  const cursorPosition = resolvePromptTerminalCursorPosition(placement, isActive, layoutKey, origin);
+  setCursorPosition(cursorPosition);
+  return cursorPosition !== undefined;
+}
 
-  useLayoutEffect(() => {
-    if (!isActive || !stdout?.isTTY) {
-      return;
+export function resolvePromptTerminalCursorPosition(
+  placement: CursorPlacement,
+  isActive: boolean,
+  layoutKey: string,
+  origin: PromptCursorOrigin | null
+): { x: number; y: number } | undefined {
+  if (!isActive || origin?.layoutKey !== layoutKey) {
+    return undefined;
+  }
+
+  return {
+    x: Math.max(0, Math.round(origin.left + placement.column)),
+    y: Math.max(0, Math.round(origin.top + placement.row)),
+  };
+}
+
+function getAbsoluteElementPosition(element: DOMElement | null): { left: number; top: number } | null {
+  let current: DOMElement | undefined = element ?? undefined;
+  let left = 0;
+  let top = 0;
+
+  while (current) {
+    const layout = current.yogaNode?.getComputedLayout();
+    if (!layout) {
+      return null;
     }
+    left += layout.left;
+    top += layout.top;
+    current = current.parentNode;
+  }
 
-    unmountingRef.current = false;
-    const directWrite = directWriteRef.current;
-    if (!directWrite) {
-      return;
-    }
-
-    directWrite(showCursor() + cursorUp(placement.rowsUp) + "\r" + cursorForward(placement.column));
-    activePlacementRef.current = placement;
-    lastPlacementRef.current = placement;
-
-    return () => {
-      unmountingRef.current = true;
-      lastPlacementRef.current = null;
-      const activePlacement = activePlacementRef.current;
-      if (!activePlacement) {
-        return;
-      }
-      directWrite("\r" + cursorDown(activePlacement.rowsUp) + hideCursor());
-      activePlacementRef.current = null;
-    };
-  }, [isActive, placement, stdout]);
+  return { left, top };
 }
 
 export function useHiddenTerminalCursor(stdout: NodeJS.WriteStream | undefined, isActive: boolean): void {

--- a/src/ui/hooks/index.ts
+++ b/src/ui/hooks/index.ts
@@ -8,6 +8,8 @@ export {
   usePromptTerminalCursor,
   useTerminalFocusReporting,
   getPromptCursorPlacement,
+  isPromptCursorAtWrapBoundary,
+  resolvePromptTerminalCursorPosition,
 } from "./cursor";
 
 export { usePasteHandling } from "./usePasteHandling";

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -6,7 +6,13 @@ import {
 
 export { getThinkingOptionIndex, MODEL_COMMAND_MODELS, MODEL_COMMAND_THINKING_OPTIONS };
 export { buildPromptDraftFromSessionMessage } from "./utils";
-export { disableTerminalExtendedKeys, enableTerminalExtendedKeys, getPromptCursorPlacement } from "./hooks/cursor";
+export {
+  disableTerminalExtendedKeys,
+  enableTerminalExtendedKeys,
+  getPromptCursorPlacement,
+  isPromptCursorAtWrapBoundary,
+  resolvePromptTerminalCursorPosition,
+} from "./hooks/cursor";
 export { default as AppContainer } from "./views/AppContainer";
 export { AskUserQuestionPrompt } from "./views/AskUserQuestionPrompt";
 export { MessageView } from "./components";

--- a/src/ui/views/App.tsx
+++ b/src/ui/views/App.tsx
@@ -48,11 +48,46 @@ import { SessionManager } from "../../session";
 
 type View = "chat" | "session-list" | "undo" | "mcp-status";
 
+const STATUS_SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
 type AppProps = {
   projectRoot: string;
   initialPrompt?: string;
   onRestart?: () => void;
 };
+
+const StatusLine = React.memo(function StatusLine({
+  busy,
+  text,
+}: {
+  busy: boolean;
+  text?: string;
+}): React.ReactElement {
+  const [spinnerIndex, setSpinnerIndex] = useState(0);
+
+  useEffect(() => {
+    if (!busy) {
+      setSpinnerIndex(0);
+      return;
+    }
+
+    const timer = setInterval(() => {
+      setSpinnerIndex((index) => (index + 1) % STATUS_SPINNER_FRAMES.length);
+    }, 80);
+    return () => clearInterval(timer);
+  }, [busy]);
+
+  return (
+    <Box>
+      {busy ? (
+        <Box marginRight={1}>
+          <Text color="yellow">{STATUS_SPINNER_FRAMES[spinnerIndex]}</Text>
+        </Box>
+      ) : null}
+      {text ? <Text dimColor>{text}</Text> : null}
+    </Box>
+  );
+});
 
 function App({ projectRoot, initialPrompt, onRestart }: AppProps): React.ReactElement {
   const { exit } = useApp();
@@ -641,6 +676,35 @@ function App({ projectRoot, initialPrompt, onRestart }: AppProps): React.ReactEl
     }
     return messages;
   }, [mode, showWelcome, view, messages, welcomeItem]);
+  const promptCursorLayoutKey = useMemo(() => {
+    const lastStaticItem = staticItems.at(-1);
+    return [
+      view,
+      busy ? "busy" : "idle",
+      statusLine,
+      errorLine ?? "",
+      showProcessStdout ? "stdout" : "main",
+      activeStatus ?? "",
+      staticItems.length,
+      lastStaticItem?.id ?? "",
+      lastStaticItem?.updateTime ?? "",
+      shouldShowQuestionPrompt ? (pendingQuestion?.messageId ?? "") : "",
+      activeAskPermissions?.length ?? 0,
+      pendingPermissionReply ? "pending-permission-reply" : "no-pending-permission-reply",
+    ].join("\u001E");
+  }, [
+    activeAskPermissions,
+    activeStatus,
+    busy,
+    errorLine,
+    pendingPermissionReply,
+    pendingQuestion,
+    shouldShowQuestionPrompt,
+    showProcessStdout,
+    staticItems,
+    statusLine,
+    view,
+  ]);
 
   const handleQuestionAnswers = useCallback(
     (answers: AskUserQuestionAnswers) => {
@@ -724,11 +788,7 @@ function App({ projectRoot, initialPrompt, onRestart }: AppProps): React.ReactEl
           );
         }}
       </Static>
-      {statusLine ? (
-        <Box>
-          <Text dimColor>{statusLine}</Text>
-        </Box>
-      ) : null}
+      {busy || statusLine ? <StatusLine busy={busy} text={statusLine} /> : null}
       {errorLine ? (
         <Box>
           <Text color="red">Error: {errorLine}</Text>
@@ -802,6 +862,7 @@ function App({ projectRoot, initialPrompt, onRestart }: AppProps): React.ReactEl
           modelConfig={resolvedSettings}
           promptHistory={promptHistory}
           busy={busy}
+          cursorLayoutKey={promptCursorLayoutKey}
           loadingText={loadingText}
           runningProcesses={runningProcesses}
           promptDraft={promptDraft}

--- a/src/ui/views/PromptInput.tsx
+++ b/src/ui/views/PromptInput.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Box, Text, useApp, useStdout } from "ink";
+import type { DOMElement } from "ink";
 import chalk from "chalk";
 import { ARGS_SEPARATOR } from "../constants";
 import {
@@ -48,6 +49,7 @@ import {
   usePasteHandling,
   useHistoryNavigation,
   getPromptCursorPlacement,
+  isPromptCursorAtWrapBoundary,
   usePromptTerminalCursor,
 } from "../hooks";
 import type { InputKey } from "../hooks";
@@ -98,6 +100,7 @@ type Props = {
 };
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const PROMPT_PREFIX_WIDTH = 2;
 
 const PromptPrefixLine = React.memo(function PromptPrefixLine({ busy }: { busy: boolean }): React.ReactElement {
   const [spinnerIndex, setSpinnerIndex] = useState(0);
@@ -141,6 +144,7 @@ export const PromptInput = React.memo(function PromptInput({
 }: Props): React.ReactElement {
   const { exit } = useApp();
   const { stdout } = useStdout();
+  const inputTextRef = useRef<DOMElement | null>(null);
   const [buffer, setBuffer] = useState<PromptBufferState>(EMPTY_BUFFER);
   const [imageUrls, setImageUrls] = useState<string[]>([]);
   const [selectedSkills, setSelectedSkills] = useState<SkillInfo[]>([]);
@@ -212,17 +216,28 @@ export const PromptInput = React.memo(function PromptInput({
     () => showMenu || showSkillsDropdown || openRawModelDropdown || showModelDropdown || showFileMentionMenu,
     [showMenu, showSkillsDropdown, showModelDropdown, openRawModelDropdown, showFileMentionMenu]
   );
+  const inputContentWidth = Math.max(1, screenWidth - PROMPT_PREFIX_WIDTH);
 
   const cursorPlacement = useMemo(
-    () => getPromptCursorPlacement(buffer, screenWidth, 2, footerText),
-    [buffer, footerText, screenWidth]
+    () => getPromptCursorPlacement(buffer, inputContentWidth),
+    [buffer, inputContentWidth]
   );
-  const usePositionedCursor = !disabled && hasTerminalFocus && !showFooterText;
+  const useInlineCursor = isPromptCursorAtWrapBoundary(buffer, inputContentWidth);
+  const usePositionedCursor = !disabled && hasTerminalFocus && !showFooterText && stdout.isTTY && !useInlineCursor;
+  const promptCursorLayoutKey = useMemo(
+    () => [screenWidth, imageUrls.length, selectedSkills.map((skill) => skill.name).join("\u001F")].join("\u001E"),
+    [imageUrls.length, screenWidth, selectedSkills]
+  );
   useTerminalFocusReporting(stdout, !disabled);
   useTerminalExtendedKeys(stdout, !disabled);
   useBracketedPaste(stdout, !disabled);
-  usePromptTerminalCursor(stdout, cursorPlacement, usePositionedCursor);
-  useHiddenTerminalCursor(stdout, !disabled && !usePositionedCursor);
+  const terminalCursorActive = usePromptTerminalCursor(
+    inputTextRef,
+    cursorPlacement,
+    usePositionedCursor,
+    promptCursorLayoutKey
+  );
+  useHiddenTerminalCursor(stdout, !disabled && !terminalCursorActive);
 
   const refreshFileMentionItems = React.useCallback(() => {
     setFileMentionItems(scanFileMentionItems(projectRoot));
@@ -765,8 +780,16 @@ export const PromptInput = React.memo(function PromptInput({
         borderDimColor
       >
         <PromptPrefixLine busy={busy} />
-        <Box flexGrow={1} flexShrink={1} width={screenWidth - 2}>
-          <Text>{renderBufferWithCursor(buffer, !disabled && hasTerminalFocus, placeholder, pastesRef.current)}</Text>
+        <Box ref={inputTextRef} flexGrow={1} flexShrink={1} width={inputContentWidth}>
+          <Text wrap="hard">
+            {renderBufferWithCursor(
+              buffer,
+              !disabled && hasTerminalFocus,
+              placeholder,
+              pastesRef.current,
+              !terminalCursorActive
+            )}
+          </Text>
           {inlineHint ? <Text dimColor>{inlineHint}</Text> : null}
         </Box>
       </Box>
@@ -885,24 +908,28 @@ export function renderBufferWithCursor(
   state: PromptBufferState,
   isFocused: boolean,
   placeholder?: string,
-  validPastes?: Map<number, string>
+  validPastes?: Map<number, string>,
+  showSimulatedCursor = true
 ): string {
   const text = state.text || "";
   const cursor = Math.max(0, Math.min(state.cursor, text.length));
   const validIds = validPastes ?? new Map<number, string>();
 
   if (text.length === 0 && placeholder) {
-    if (!isFocused) {
+    if (!isFocused || !showSimulatedCursor) {
       return chalk.dim(`  ${placeholder}`);
     }
     return renderCursorCell(" ") + chalk.dim(` ${placeholder}`);
   }
 
   if (text.length === 0) {
-    return isFocused ? renderCursorCell(" ") : "";
+    if (!isFocused) {
+      return "";
+    }
+    return showSimulatedCursor ? renderCursorCell(" ") : " ";
   }
 
-  if (!isFocused) {
+  if (!isFocused || !showSimulatedCursor) {
     return highlightPasteMarkersInText(text, validIds);
   }
 
@@ -910,7 +937,7 @@ export function renderBufferWithCursor(
 }
 
 function highlightPasteMarkersInText(s: string, validIds: Map<number, string>): string {
-  if (!s.includes("[paste #")) return s;
+  if (!s.includes("[paste #")) return s.endsWith("\n") ? `${s} ` : s;
   PASTE_MARKER_REGEX.lastIndex = 0;
   let result = "";
   let pos = 0;

--- a/src/ui/views/PromptInput.tsx
+++ b/src/ui/views/PromptInput.tsx
@@ -87,6 +87,7 @@ type Props = {
   screenWidth: number;
   promptHistory: string[];
   busy: boolean;
+  cursorLayoutKey?: string;
   loadingText?: string | null;
   disabled?: boolean;
   placeholder?: string;
@@ -99,27 +100,12 @@ type Props = {
   onToggleProcessStdout?: () => void;
 };
 
-const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 const PROMPT_PREFIX_WIDTH = 2;
 
-const PromptPrefixLine = React.memo(function PromptPrefixLine({ busy }: { busy: boolean }): React.ReactElement {
-  const [spinnerIndex, setSpinnerIndex] = useState(0);
-
-  useEffect(() => {
-    if (!busy) {
-      setSpinnerIndex(0);
-      return;
-    }
-    const timer = setInterval(() => {
-      setSpinnerIndex((index) => (index + 1) % SPINNER_FRAMES.length);
-    }, 80);
-    return () => clearInterval(timer);
-  }, [busy]);
-
-  const prefix = busy ? `${SPINNER_FRAMES[spinnerIndex]} ` : "> ";
+const PromptPrefixLine = React.memo(function PromptPrefixLine(): React.ReactElement {
   return (
-    <Box width={2}>
-      <Text color={busy ? "yellow" : "#229ac3"}>{prefix}</Text>
+    <Box width={PROMPT_PREFIX_WIDTH}>
+      <Text color="#229ac3">{"> "}</Text>
     </Box>
   );
 });
@@ -131,6 +117,7 @@ export const PromptInput = React.memo(function PromptInput({
   screenWidth,
   promptHistory,
   busy,
+  cursorLayoutKey,
   loadingText,
   disabled,
   placeholder,
@@ -205,12 +192,14 @@ export const PromptInput = React.memo(function PromptInput({
       : hasExpandedRegions
         ? " · ctrl+o collapse"
         : "";
+  const busyStatusText =
+    loadingText && loadingText.trim()
+      ? `${loadingText}${processOrPasteHint}`
+      : `esc to interrupt · ctrl+c to cancel input${processOrPasteHint}`;
   const footerText = statusMessage
     ? statusMessage
     : busy
-      ? loadingText && loadingText.trim()
-        ? `${loadingText}${processOrPasteHint}`
-        : `esc to interrupt · ctrl+c to cancel input${processOrPasteHint}`
+      ? busyStatusText
       : `enter send · shift+enter newline · @ files · ctrl+v image · / commands · ctrl+d exit${processOrPasteHint}`;
   const showFooterText = useMemo(
     () => showMenu || showSkillsDropdown || openRawModelDropdown || showModelDropdown || showFileMentionMenu,
@@ -225,8 +214,14 @@ export const PromptInput = React.memo(function PromptInput({
   const useInlineCursor = isPromptCursorAtWrapBoundary(buffer, inputContentWidth);
   const usePositionedCursor = !disabled && hasTerminalFocus && !showFooterText && stdout.isTTY && !useInlineCursor;
   const promptCursorLayoutKey = useMemo(
-    () => [screenWidth, imageUrls.length, selectedSkills.map((skill) => skill.name).join("\u001F")].join("\u001E"),
-    [imageUrls.length, screenWidth, selectedSkills]
+    () =>
+      [
+        screenWidth,
+        cursorLayoutKey ?? "default",
+        imageUrls.length,
+        selectedSkills.map((skill) => skill.name).join("\u001F"),
+      ].join("\u001E"),
+    [cursorLayoutKey, imageUrls.length, screenWidth, selectedSkills]
   );
   useTerminalFocusReporting(stdout, !disabled);
   useTerminalExtendedKeys(stdout, !disabled);
@@ -234,10 +229,10 @@ export const PromptInput = React.memo(function PromptInput({
   const terminalCursorActive = usePromptTerminalCursor(
     inputTextRef,
     cursorPlacement,
-    usePositionedCursor,
+    !busy && usePositionedCursor,
     promptCursorLayoutKey
   );
-  useHiddenTerminalCursor(stdout, !disabled && !terminalCursorActive);
+  useHiddenTerminalCursor(stdout, !disabled && (busy || !terminalCursorActive));
 
   const refreshFileMentionItems = React.useCallback(() => {
     setFileMentionItems(scanFileMentionItems(projectRoot));
@@ -779,7 +774,7 @@ export const PromptInput = React.memo(function PromptInput({
         borderRight={false}
         borderDimColor
       >
-        <PromptPrefixLine busy={busy} />
+        <PromptPrefixLine />
         <Box ref={inputTextRef} flexGrow={1} flexShrink={1} width={inputContentWidth}>
           <Text wrap="hard">
             {renderBufferWithCursor(
@@ -787,7 +782,7 @@ export const PromptInput = React.memo(function PromptInput({
               !disabled && hasTerminalFocus,
               placeholder,
               pastesRef.current,
-              !terminalCursorActive
+              !busy && !terminalCursorActive
             )}
           </Text>
           {inlineHint ? <Text dimColor>{inlineHint}</Text> : null}


### PR DESCRIPTION
## 变更
- 统一输入框和提交后 user prompt 回显的前缀宽度与 hard wrap 规则，避免提交后提前换行。
- 用 Ink 的光标定位能力替换手动 stdout 光标移动，减少重绘时的光标残留。
- 在输入框布局变化后，只有当前布局完成测量时才启用真实终端光标；测量完成前使用模拟光标，修复选择 skill 后光标位置错误。
- 调整 busy 状态 UI：spinner 从输入框前缀移到 status 行前方，输入框前缀始终保持 `> `。
- busy 开始但尚未收到 `statusLine` 时立即显示 spinner，避免首次提交后输入框上方空白。
- busy 状态下统一隐藏真实终端光标和模拟光标，避免 status spinner 与底部进度更新造成光标显示/隐藏冲突和闪烁；非 busy 状态继续使用 IME 友好的真实终端光标。
- 增加回归测试覆盖提交回显换行、换行边界光标，以及布局测量不匹配时禁用真实终端光标。

## 实现细节
- `src/ui/hooks/cursor.ts` 改为使用 Ink 7 的 `useCursor()` 和 `useBoxMetrics()`，不再 patch `stdout.write` 或手动写入上下移动光标的 ANSI 序列。
- 光标位置从原来的 `{ rowsUp, column }` 调整为基于输入区域的 `{ row, column }`，再结合 Ink 测量到的输入框绝对位置计算最终 `{ x, y }`。
- `PromptInput` 使用固定的 prompt 前缀宽度计算输入内容宽度，并通过 `wrap="hard"` 让实时输入、换行边界和提交后回显保持一致。
- 真实终端光标只在输入聚焦、TTY、无下拉菜单/覆盖提示、非 hard-wrap 边界、非 busy，并且当前布局已完成测量时启用。
- 当真实终端光标未确认可用时，保留 inverse-video 模拟光标作为回退；busy 状态例外，busy 时光标始终隐藏以避免闪烁。
- `App` 向 `PromptInput` 传入 `cursorLayoutKey`，将 status、视图、消息数量、最后一条消息、权限/问题提示等会改变输入框纵向位置的状态纳入布局 key，防止复用旧光标坐标。
- `StatusLine` 独立渲染 busy spinner；即使 status 文本为空，只要 busy 就会显示 spinner。
- 选中 skill、附件数量和终端宽度继续参与生成 prompt 内部布局 key，防止选择 skill 后继续使用旧布局的光标坐标。

## 验证
- `npm run typecheck`
- `npm run lint`
- `npm run format:check -- src/ui/views/App.tsx src/ui/views/PromptInput.tsx src/ui/hooks/cursor.ts src/ui/hooks/index.ts`
- `npm run test:single -- src/tests/prompt-input-keys.test.ts`
