### PR TITLE
docs: replace DeepSeek API URL in Chinese docs of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ Skills 会按以下优先级扫描：
 
 ### **为 DeepSeek 优化**
 - 专门为 DeepSeek 模型性能调优。
-- 通过使用[上下文缓存](https://api-docs.deepseek.com/guides/kv_cache)来降低成本。
-- 原生支持[思考模式](https://api-docs.deepseek.com/guides/thinking_mode)和思考强度控制。
+- 通过使用[上下文缓存](https://api-docs.deepseek.com/zh-cn/guides/kv_cache)来降低成本。
+- 原生支持[思考模式](https://api-docs.deepseek.com/zh-cn/guides/thinking_mode)和思考强度控制。
 
 ## 斜杠命令与按键功能
 


### PR DESCRIPTION
- 替换 README 中文文档中的 DeepSeek API URL
- 中文部分中的链接可打开 DeepSeek API 文档的中文版本。
- 这避免了每次单击链接后都需要切换语言。
- 它还会避免代理在中文上下文中阅读英文内容。