### PR TITLE
build(cli): 重构构建流程并内联核心及依赖

### DIFF
--- a/.deepcode/AGENTS.md
+++ b/.deepcode/AGENTS.md
@@ -68,8 +68,8 @@ dist/                    # Bundled CLI output (gitignored)
 | `npm run format` | Prettier on all `src/**/*.{ts,tsx}` |
 | `npm run format:check` | Prettier in check-only mode |
 | `npm run check` | Runs typecheck + lint + format:check together |
-| `npm run bundle` | esbuild bundles `src/cli.tsx` → `dist/cli.js` (ESM, Node 18) |
-| `npm run build` | `check` + `bundle` + chmod 755 — full CI gate before publish |
+| `npm run bundle` | esbuild bundles cli + core + all deps → `dist/cli.js` (ESM, Node 22) |
+| `npm run build` | build core (tsc) + rewrite ESM imports + bundle CLI (esbuild) |
 | `npm test` | Runs all tests via `node src/tests/run-tests.mjs` |
 | `npm run test:single -- <file>` | Run a single test file via `tsx --test` (e.g., `npm run test:single -- src/tests/session.test.ts`) |
 

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# VS Code Marketplace publish token
+# Generate at: https://dev.azure.com/vegamo/_usersSettings/tokens
+# Permission required: Marketplace → Publish
+VSCE_PAT=

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ out/
 # TypeScript build info files
 *.tsbuildinfo
 
+# Environment variables
+.env
+.env.local
+
 # Generated files
 packages/cli/src/generated/
 packages/core/src/generated/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -105,7 +105,7 @@ git tag v0.1.32
 
 ## prepare:package — 构建并发布到 npm
 
-完成质量检查、构建、发布两个 npm 包，并自动创建 git commit 和 tag。
+完成质量检查、构建、发布 CLI 到 npm，并自动创建 git commit 和 tag。
 
 ### 基本用法
 
@@ -122,7 +122,7 @@ npm run prepare:package -- <version> [options]
 | `--dry-run` | 预演模式，不实际执行任何写操作 |
 | `--force` | 跳过 main 分支检查，允许从其他分支发布 |
 
-### 执行流程（9 步）
+### 执行流程（8 步）
 
 | 步骤 | 操作 | 说明 |
 |------|------|------|
@@ -131,10 +131,9 @@ npm run prepare:package -- <version> [options]
 | 3 | 更新版本号 | 同时更新 `packages/core` 和 `packages/cli` 的 version |
 | 4 | 质量检查 | `npm run check`（typecheck + eslint + prettier） |
 | 5 | 测试 | `npm run test --workspaces` |
-| 6 | 构建 | `npm run build`（core tsc + cli esbuild bundle） |
-| 7 | 发布 core | `npm publish --workspace=@vegamo/deepcode-core --access public` |
-| 8 | 发布 cli | 将 cli 的 `@vegamo/deepcode-core` 依赖从 `file:../core` 临时改为 `^<version>`，发布后恢复 |
-| 9 | Git commit & tag | `chore(release): v<version>` + `git tag v<version>` |
+| 6 | 构建 | `npm run build`（core tsc + esbuild 将 core 及所有依赖内联到 `dist/cli.js`） |
+| 7 | 发布 CLI | 往 `dist/` 写入 `dependencies: {}` 的 package.json，从 `dist/` 目录执行 `npm publish` |
+| 8 | Git commit & tag | `chore(release): v<version>` + `git tag v<version>` |
 
 ### 完整示例
 
@@ -152,9 +151,9 @@ npm run prepare:package -- 0.1.32 --dry-run
 npm run prepare:package -- 0.1.32 --force
 ```
 
-### 关于 file:../core 依赖
+### 关于 Core 打包策略
 
-CLI 包的 `@vegamo/deepcode-core` 依赖在开发时使用 `"file:../core"`（monorepo 本地链接）。发布到 npm 时，脚本会自动将其替换为 `"^<version>"`，发布完成后恢复为 `file:../core`。这个过程对用户透明，无需手动处理。
+CLI 的 `package.json` 中保留 `"@vegamo/deepcode-core": "file:../core"` 用于本地开发（IDE 类型检查、monorepo 工作区解析）。构建时 esbuild 使用 `packages: "bundle"` 将 core 的全部代码及其运行时依赖（`openai`、`ejs`、`zod` 等）内联到单个 `dist/cli.js` 文件中。发布时脚本往 `dist/` 写入 `dependencies: {}` 的 `package.json`，从 `dist/` 目录发布，因此发布的 CLI 包零运行时依赖。`@vegamo/deepcode-core` 不再作为独立 npm 包发布。
 
 ### 发布后
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,13 +1,14 @@
 # 版本发布
 
-Deep Code 使用两个脚本管理 monorepo 的版本发布流程：
+Deep Code 使用三个脚本管理 monorepo 的版本发布流程：
 
 | 脚本 | 命令 | 用途 |
 |------|------|------|
 | `scripts/version.js` | `npm run release:version` | 升级所有 workspace 包的版本号 + 重新生成 lockfile |
-| `scripts/prepare-package.js` | `npm run prepare:package` | 构建 + 质量检查 + 发布到 npm + git commit & tag |
+| `scripts/prepare-package.js` | `npm run prepare:package` | 构建 CLI + 质量检查 + 发布到 npm + git commit & tag |
+| `scripts/prepare-vscode.js` | `npm run prepare:vscode` | 构建 VSCode 扩展 + 质量检查 + 发布到 VS Code 市场 + git commit & tag |
 
-两者配合使用，先升版本号，再发布。
+发布流程：先升版本号，再分别发布 CLI 和 VSCode 扩展。
 
 ---
 
@@ -172,6 +173,58 @@ npx @vegamo/deepcode-cli --version
 
 ---
 
+## prepare:vscode — 构建并发布 VSCode 扩展到市场
+
+完成质量检查、构建、发布 VSCode 扩展到 VS Code Marketplace，并自动创建 git commit 和 tag。
+
+### 前置条件
+
+需要 Azure DevOps Personal Access Token（PAT）用于市场认证：
+
+1. 访问 https://dev.azure.com/vegamo/_usersSettings/tokens 生成 token
+2. 设置环境变量 `VSCE_PAT=<token>`
+
+### 基本用法
+
+```bash
+VSCE_PAT=<token> npm run prepare:vscode -- <version> [options]
+```
+
+### 参数
+
+| 参数 | 说明 |
+|------|------|
+| `<version>` | **必填**，要发布的 semver 版本号 |
+| `--dry-run` | 预演模式，不实际执行任何写操作 |
+| `--force` | 跳过 main 分支检查，允许从其他分支发布 |
+
+### 执行流程（7 步）
+
+| 步骤 | 操作 | 说明 |
+|------|------|------|
+| 1 | Git 检查 | 工作区必须 clean，必须在 main 分支 |
+| 2 | VSCE_PAT 检查 | 环境变量必须已设置 |
+| 3 | 更新版本号 | 同时更新 `packages/core`、`packages/cli`、`packages/vscode-ide-companion` 的 version |
+| 4 | 质量检查 | `npm run check`（typecheck + eslint + prettier） |
+| 5 | 测试 | `npm run test --workspaces` |
+| 6 | 构建 | `npm run build:vscode`（core tsc + esbuild 打包扩展 + 拷贝模板 + vsce package） |
+| 7 | 发布 | `vsce publish <version> --no-dependencies` 发布到 VS Code Marketplace |
+
+### 完整示例
+
+```bash
+# 发布正式版
+VSCE_PAT=xxx npm run prepare:vscode -- 0.1.32
+
+# 发布预发布版
+VSCE_PAT=xxx npm run prepare:vscode -- 0.1.32-beta.1
+
+# 预演（不实际发布）
+npm run prepare:vscode -- 0.1.32 --dry-run
+```
+
+---
+
 ## 典型发布流程
 
 一个完整的版本发布通常按以下步骤进行：
@@ -190,18 +243,22 @@ git diff
 git add -A
 git commit -m "chore(release): v0.1.32"
 
-# 5. 构建 + 质量检查 + 发布
+# 5. 构建 + 质量检查 + 发布 CLI
 npm run prepare:package -- 0.1.32
 
-# 6. 推送到 remote
+# 6. 发布 VSCode 扩展
+VSCE_PAT=xxx npm run prepare:vscode -- 0.1.32
+
+# 7. 推送到 remote
 git push && git push --tags
 ```
 
-也可以简化为两步（`prepare:package` 会自动 commit 和 tag）：
+也可以简化为三步（`prepare:package` 和 `prepare:vscode` 各自自动 commit 和 tag）：
 
 ```bash
 npm run release:version -- patch
 npm run prepare:package -- 0.1.32
+VSCE_PAT=xxx npm run prepare:vscode -- 0.1.32
 git push && git push --tags
 ```
 

--- a/RELEASE_en.md
+++ b/RELEASE_en.md
@@ -105,7 +105,7 @@ git tag v0.1.32
 
 ## prepare:package — Build and Publish to npm
 
-Runs quality checks, builds, publishes both npm packages, and automatically creates a git commit with tag.
+Runs quality checks, builds, publishes the CLI to npm, and automatically creates a git commit with tag.
 
 ### Basic Usage
 
@@ -122,7 +122,7 @@ npm run prepare:package -- <version> [options]
 | `--dry-run` | Preview mode, no actual writes |
 | `--force` | Skip main branch check, allow publishing from other branches |
 
-### Execution Flow (9 Steps)
+### Execution Flow (8 Steps)
 
 | Step | Action | Description |
 |------|--------|-------------|
@@ -131,10 +131,9 @@ npm run prepare:package -- <version> [options]
 | 3 | Update versions | Updates `packages/core` and `packages/cli` version fields |
 | 4 | Quality checks | `npm run check` (typecheck + eslint + prettier) |
 | 5 | Tests | `npm run test --workspaces` |
-| 6 | Build | `npm run build` (core tsc + cli esbuild bundle) |
-| 7 | Publish core | `npm publish --workspace=@vegamo/deepcode-core --access public` |
-| 8 | Publish cli | Temporarily changes cli's `@vegamo/deepcode-core` dep from `file:../core` to `^<version>`, restores after publish |
-| 9 | Git commit & tag | `chore(release): v<version>` + `git tag v<version>` |
+| 6 | Build | `npm run build` (core tsc + esbuild inlines core and all deps into `dist/cli.js`) |
+| 7 | Publish CLI | Writes `dist/package.json` with `dependencies: {}`, runs `npm publish` from `dist/` |
+| 8 | Git commit & tag | `chore(release): v<version>` + `git tag v<version>` |
 
 ### Examples
 
@@ -152,9 +151,9 @@ npm run prepare:package -- 0.1.32 --dry-run
 npm run prepare:package -- 0.1.32 --force
 ```
 
-### About the file:../core Dependency
+### About the Core Bundling Strategy
 
-The CLI package uses `"file:../core"` for the `@vegamo/deepcode-core` dependency during development (monorepo local link). When publishing to npm, the script automatically replaces it with `"^<version>"` and restores it after publishing. This is transparent — no manual handling required.
+The CLI's `package.json` keeps `"@vegamo/deepcode-core": "file:../core"` for local development (IDE type checking, monorepo workspace resolution). At build time, esbuild uses `packages: "bundle"` to inline all of core's code and its runtime dependencies (`openai`, `ejs`, `zod`, etc.) into a single `dist/cli.js` file. At publish time, the script writes a `dist/package.json` with `dependencies: {}` and publishes from the `dist/` directory, so the published CLI package has zero runtime dependencies. `@vegamo/deepcode-core` is no longer published as a separate npm package.
 
 ### After Publishing
 

--- a/RELEASE_en.md
+++ b/RELEASE_en.md
@@ -1,13 +1,14 @@
 # Release
 
-Deep Code uses two scripts to manage version releases in the monorepo:
+Deep Code uses three scripts to manage version releases in the monorepo:
 
 | Script | Command | Purpose |
 |--------|---------|---------|
 | `scripts/version.js` | `npm run release:version` | Bump all workspace package versions + regenerate lockfile |
-| `scripts/prepare-package.js` | `npm run prepare:package` | Build + quality checks + publish to npm + git commit & tag |
+| `scripts/prepare-package.js` | `npm run prepare:package` | Build CLI + quality checks + publish to npm + git commit & tag |
+| `scripts/prepare-vscode.js` | `npm run prepare:vscode` | Build VSCode extension + quality checks + publish to VS Code Marketplace + git commit & tag |
 
-Use them together: bump version first, then publish.
+Release flow: bump version first, then publish CLI and VSCode extension separately.
 
 ---
 
@@ -172,6 +173,58 @@ npx @vegamo/deepcode-cli --version
 
 ---
 
+## prepare:vscode — Build and Publish VSCode Extension to Marketplace
+
+Runs quality checks, builds, publishes the VSCode extension to the VS Code Marketplace, and automatically creates a git commit with tag.
+
+### Prerequisites
+
+Requires an Azure DevOps Personal Access Token (PAT) for marketplace authentication:
+
+1. Generate a token at https://dev.azure.com/vegamo/_usersSettings/tokens
+2. Set the environment variable `VSCE_PAT=<token>`
+
+### Basic Usage
+
+```bash
+VSCE_PAT=<token> npm run prepare:vscode -- <version> [options]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `<version>` | **Required**. Semver version to publish |
+| `--dry-run` | Preview mode, no actual writes |
+| `--force` | Skip main branch check, allow publishing from other branches |
+
+### Execution Flow (7 Steps)
+
+| Step | Action | Description |
+|------|--------|-------------|
+| 1 | Git check | Working tree must be clean, must be on main branch |
+| 2 | VSCE_PAT check | Environment variable must be set |
+| 3 | Update versions | Updates `packages/core`, `packages/cli`, and `packages/vscode-ide-companion` version fields |
+| 4 | Quality checks | `npm run check` (typecheck + eslint + prettier) |
+| 5 | Tests | `npm run test --workspaces` |
+| 6 | Build | `npm run build:vscode` (core tsc + esbuild bundle extension + copy templates + vsce package) |
+| 7 | Publish | `vsce publish <version> --no-dependencies` to VS Code Marketplace |
+
+### Examples
+
+```bash
+# Publish stable release
+VSCE_PAT=xxx npm run prepare:vscode -- 0.1.32
+
+# Publish pre-release
+VSCE_PAT=xxx npm run prepare:vscode -- 0.1.32-beta.1
+
+# Dry run (no actual publish)
+npm run prepare:vscode -- 0.1.32 --dry-run
+```
+
+---
+
 ## Typical Release Flow
 
 A complete version release follows these steps:
@@ -190,18 +243,22 @@ git diff
 git add -A
 git commit -m "chore(release): v0.1.32"
 
-# 5. Build + quality check + publish
+# 5. Build + quality check + publish CLI
 npm run prepare:package -- 0.1.32
 
-# 6. Push to remote
+# 6. Publish VSCode extension
+VSCE_PAT=xxx npm run prepare:vscode -- 0.1.32
+
+# 7. Push to remote
 git push && git push --tags
 ```
 
-Or simplified to two steps (`prepare:package` auto-commits and tags):
+Or simplified to three steps (`prepare:package` and `prepare:vscode` each auto-commit and tag):
 
 ```bash
 npm run release:version -- patch
 npm run prepare:package -- 0.1.32
+VSCE_PAT=xxx npm run prepare:vscode -- 0.1.32
 git push && git push --tags
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "husky": "^9.1.7",
         "lint-staged": "^17.0.4",
         "prettier": "^3.8.3",
+        "react-devtools-core": "^7.0.1",
         "tsx": "^4.21.0",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.2"
@@ -5984,6 +5985,39 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-devtools-core": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-7.0.1.tgz",
+      "integrity": "sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "shell-quote": "^1.6.1",
+        "ws": "^7"
+      }
+    },
+    "node_modules/react-devtools-core/node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-reconciler": {
       "version": "0.33.0",
       "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
@@ -6275,6 +6309,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test": "npm run test --workspaces --if-present",
     "release:version": "node scripts/version.js",
     "prepare:package": "node scripts/prepare-package.js",
+    "prepare:vscode": "node scripts/prepare-vscode.js",
     "prepare": "husky && npm run build && npm run bundle"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^17.0.4",
     "prettier": "^3.8.3",
+    "react-devtools-core": "^7.0.1",
     "tsx": "^4.21.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.2"

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -818,12 +818,15 @@ ${agentInstructions}
   private getBundledSkillsRoot(): string {
     const extensionRoot = getExtensionRoot();
     const sourceRoot = path.join(extensionRoot, "templates", "skills", "bundled");
-    const distRoot = path.join(extensionRoot, "dist", "bundled");
 
     // Source check keeps local development/tests on the checked-in templates.
     if (fs.existsSync(path.join(extensionRoot, "src", "session.ts")) && fs.existsSync(sourceRoot)) {
       return sourceRoot;
     }
+
+    // In the published bundle, getExtensionRoot() resolves to dist/ and
+    // bundled skills are copied to dist/bundled/ (not dist/templates/skills/bundled/).
+    const distRoot = path.join(extensionRoot, "bundled");
     return fs.existsSync(distRoot) ? distRoot : sourceRoot;
   }
 

--- a/scripts/copy-bundle-assets.js
+++ b/scripts/copy-bundle-assets.js
@@ -1,5 +1,5 @@
-import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { cpSync, existsSync, mkdirSync, rmSync, statSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -7,31 +7,34 @@ const root = join(__dirname, "..");
 const cliRoot = join(root, "packages", "cli");
 const distDir = join(cliRoot, "dist");
 
-// 1. Copy core/templates/ → dist/templates/
-//    Core's getExtensionRoot() resolves to dist/ in the bundle (because
-//    __dirname is dist/chunks/ and ".." goes up to dist/).  The runtime code
-//    loads templates from extensionRoot + "/templates/...", so they must
-//    exist at dist/templates/.
-const templatesSrc = join(root, "packages", "core", "templates");
-const templatesDest = join(distDir, "templates");
-
 if (!existsSync(distDir)) {
   mkdirSync(distDir, { recursive: true });
 }
+
+const templatesSrc = join(root, "packages", "core", "templates");
+const templatesDest = join(distDir, "templates");
 
 if (!existsSync(templatesSrc)) {
   console.error(`Templates directory not found at ${templatesSrc}`);
   process.exit(1);
 }
 
+// 1. Copy core/templates/ → dist/templates/, excluding skills/bundled/.
+//    Bundled skills are copied separately to dist/bundled/ (see step 2) and
+//    getBundledSkillsRoot() resolves them from there at runtime.
 rmSync(templatesDest, { recursive: true, force: true });
 cpSync(templatesSrc, templatesDest, {
   recursive: true,
   dereference: true,
+  filter: (src) => {
+    const rel = relative(templatesSrc, src);
+    // Exclude skills/bundled and everything under it
+    return !(rel === join("skills", "bundled") || rel.startsWith(join("skills", "bundled") + "/"));
+  },
 });
-console.log("\n✅  Copied core/templates/ → dist/templates/");
+console.log("\n✅  Copied core/templates/ → dist/templates/ (excluding skills/bundled/)");
 
-// 2. Copy bundled skills to dist/bundled/ (legacy path used by getBundledSkillsRoot fallback)
+// 2. Copy bundled skills to dist/bundled/
 const bundledSkillsSrc = join(templatesSrc, "skills", "bundled");
 const bundledSkillsDest = join(distDir, "bundled");
 

--- a/scripts/copy-bundle-assets.js
+++ b/scripts/copy-bundle-assets.js
@@ -6,22 +6,42 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, "..");
 const cliRoot = join(root, "packages", "cli");
 const distDir = join(cliRoot, "dist");
-const bundledSkillsSrc = join(root, "packages", "core", "templates", "skills", "bundled");
-const bundledSkillsDest = join(distDir, "bundled");
+
+// 1. Copy core/templates/ → dist/templates/
+//    Core's getExtensionRoot() resolves to dist/ in the bundle (because
+//    __dirname is dist/chunks/ and ".." goes up to dist/).  The runtime code
+//    loads templates from extensionRoot + "/templates/...", so they must
+//    exist at dist/templates/.
+const templatesSrc = join(root, "packages", "core", "templates");
+const templatesDest = join(distDir, "templates");
 
 if (!existsSync(distDir)) {
   mkdirSync(distDir, { recursive: true });
 }
 
-if (!existsSync(bundledSkillsSrc)) {
-  console.error(`Bundled skills directory not found at ${bundledSkillsSrc}`);
+if (!existsSync(templatesSrc)) {
+  console.error(`Templates directory not found at ${templatesSrc}`);
   process.exit(1);
 }
 
-rmSync(bundledSkillsDest, { recursive: true, force: true });
-cpSync(bundledSkillsSrc, bundledSkillsDest, {
+rmSync(templatesDest, { recursive: true, force: true });
+cpSync(templatesSrc, templatesDest, {
   recursive: true,
   dereference: true,
 });
+console.log("\n✅  Copied core/templates/ → dist/templates/");
 
-console.log("\n✅  All bundle assets copied to dist/bundled/");
+// 2. Copy bundled skills to dist/bundled/ (legacy path used by getBundledSkillsRoot fallback)
+const bundledSkillsSrc = join(templatesSrc, "skills", "bundled");
+const bundledSkillsDest = join(distDir, "bundled");
+
+if (existsSync(bundledSkillsSrc)) {
+  rmSync(bundledSkillsDest, { recursive: true, force: true });
+  cpSync(bundledSkillsSrc, bundledSkillsDest, {
+    recursive: true,
+    dereference: true,
+  });
+  console.log("✅  Copied bundled skills → dist/bundled/");
+}
+
+console.log("\n✅  All bundle assets copied.\n");

--- a/scripts/empty-shim.js
+++ b/scripts/empty-shim.js
@@ -1,0 +1,2 @@
+// Empty shim for react-devtools-core (browser-only, not needed in CLI bundle)
+export default {};

--- a/scripts/esbuild-shims.js
+++ b/scripts/esbuild-shims.js
@@ -1,0 +1,22 @@
+/**
+ * Shims for esbuild ESM bundles.
+ *
+ * When esbuild bundles CJS modules into ESM output, it replaces require()
+ * calls with a __require shim that throws for non-bundled modules.  This
+ * file provides a real require() via createRequire() so Node.js built-in
+ * modules (assert, events, zlib, etc.) resolve correctly at runtime.
+ */
+
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+
+const _require = createRequire(import.meta.url);
+
+if (typeof globalThis.require === "undefined") {
+  globalThis.require = _require;
+}
+
+export const require = _require;
+export const __filename = fileURLToPath(import.meta.url);
+export const __dirname = dirname(__filename);

--- a/scripts/esbuild.config.js
+++ b/scripts/esbuild.config.js
@@ -7,23 +7,37 @@ const root = join(__dirname, "..");
 
 const cliRoot = join(root, "packages", "cli");
 const entry = join(cliRoot, "src", "cli.tsx");
-const outfile = join(cliRoot, "dist", "cli.js");
 
 await build({
   entryPoints: [entry],
   bundle: true,
+  outdir: join(cliRoot, "dist"),
+  entryNames: "[name]",
+  chunkNames: "chunks/[name]-[hash]",
+  splitting: true,
   platform: "node",
   format: "esm",
   target: "node22",
-  outfile,
   banner: { js: "#!/usr/bin/env node" },
   jsx: "automatic",
   jsxImportSource: "react",
-  packages: "external",
-  external: ["@vegamo/deepcode-core"],
+  packages: "bundle",
+  inject: [join(__dirname, "esbuild-shims.js")],
+  alias: {
+    // react-devtools-core is a browser-only package pulled in by ink's
+    // devtools support.  It cannot run in a Node.js CLI, so we replace it
+    // with an empty shim so esbuild doesn't bundle the real (broken) code.
+    "react-devtools-core": join(__dirname, "empty-shim.js"),
+  },
+  define: {
+    "process.env.NODE_ENV": JSON.stringify("production"),
+  },
   logOverride: {
     "empty-import-meta": "silent",
   },
+  metafile: true,
+  write: true,
+  keepNames: true,
 });
 
-console.log(`\n✅  ${outfile}  built successfully\n\n`);
+console.log(`\n✅  ${join(cliRoot, "dist", "cli.js")}  built successfully\n\n`);

--- a/scripts/prepare-package.js
+++ b/scripts/prepare-package.js
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, copyFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -81,7 +81,7 @@ for (let i = 0; i < args.length; i++) {
 
 if (!version) {
   log(`
-Usage: node scripts/publish.js <version> [options]
+Usage: node scripts/prepare-package.js <version> [options]
 
 Arguments:
   <version>          Semver version to publish (e.g. 0.1.32, 0.2.0-beta.1)
@@ -92,9 +92,9 @@ Options:
   --force            Skip branch check (publish from non-main branch)
 
 Examples:
-  node scripts/publish.js 0.1.32
-  node scripts/publish.js 0.1.32-beta.1 --tag beta
-  node scripts/publish.js 0.1.32 --dry-run
+  node scripts/prepare-package.js 0.1.32
+  node scripts/prepare-package.js 0.1.32-beta.1 --tag beta
+  node scripts/prepare-package.js 0.1.32 --dry-run
 `);
   process.exit(1);
 }
@@ -103,7 +103,7 @@ if (!isValidSemver(version)) {
   fail(`Invalid semver version: ${version}`);
 }
 
-const TOTAL_STEPS = 9;
+const TOTAL_STEPS = 8;
 
 // ── Banner ───────────────────────────────────────────────────────────────────
 
@@ -169,9 +169,6 @@ const cliPkg = readJson(cliPkgPath);
 
 const oldVersion = corePkg.version;
 
-// Save originals for restore
-const origCliPkg = JSON.stringify(cliPkg, null, 2) + "\n";
-
 corePkg.version = version;
 cliPkg.version = version;
 
@@ -199,75 +196,88 @@ ok("All tests passed");
 
 // ── 6. Build ─────────────────────────────────────────────────────────────────
 
-step(6, TOTAL_STEPS, "Building packages...");
+step(6, TOTAL_STEPS, "Building and bundling packages...");
 
 run("npm", ["run", "build"], { dryRun });
-ok("Build complete");
+ok("Build and bundle complete");
 
-// ── 7. Publish core ──────────────────────────────────────────────────────────
+// ── 7. Prepare dist/ for publishing ──────────────────────────────────────────
 
-step(7, TOTAL_STEPS, "Publishing @vegamo/deepcode-core...");
+step(7, TOTAL_STEPS, "Preparing dist/ for publishing...");
 
-const corePublishArgs = [
-  "publish",
-  "--workspace=@vegamo/deepcode-core",
-  "--access",
-  "public",
-  "--tag",
-  tag,
-  "--registry",
-  "https://registry.npmjs.org",
-];
-if (dryRun) corePublishArgs.push("--dry-run");
+const cliRoot = join(root, "packages", "cli");
+const distDir = join(cliRoot, "dist");
+const distCliJs = join(distDir, "cli.js");
+const distChunks = join(distDir, "chunks");
+const distBundled = join(distDir, "bundled");
 
-run("npm", corePublishArgs, { dryRun, label: `npm ${corePublishArgs.join(" ")}` });
-ok(`Published @vegamo/deepcode-core@${version}`);
-
-// ── 8. Patch CLI deps & publish ──────────────────────────────────────────────
-
-step(8, TOTAL_STEPS, "Patching CLI dependencies and publishing @vegamo/deepcode-cli...");
-
-// Replace file:../core with ^version for npm
-const patchedCliPkg = readJson(cliPkgPath);
-const coreDep = patchedCliPkg.dependencies["@vegamo/deepcode-core"];
-if (coreDep && coreDep.startsWith("file:")) {
-  patchedCliPkg.dependencies["@vegamo/deepcode-core"] = `^${version}`;
-  if (!dryRun) {
-    writeJson(cliPkgPath, patchedCliPkg);
-  }
-  log(`  Patched @vegamo/deepcode-core dep: "${coreDep}" → "^${version}"`);
+if (!existsSync(distCliJs)) {
+  fail(`Bundle artifact not found: ${distCliJs}. Run "npm run build" first.`);
+}
+if (!existsSync(distChunks)) {
+  fail(`Chunks directory not found: ${distChunks}. Run "npm run build" first.`);
+}
+if (!existsSync(distBundled)) {
+  fail(`Bundled assets not found: ${distBundled}. Run "npm run build" first.`);
 }
 
-const cliPublishArgs = [
-  "publish",
-  "--workspace=@vegamo/deepcode-cli",
-  "--access",
-  "public",
-  "--tag",
-  tag,
-  "--registry",
-  "https://registry.npmjs.org",
-];
-if (dryRun) cliPublishArgs.push("--dry-run");
+// Copy README.md and LICENSE into dist/
+for (const file of ["README.md", "LICENSE"]) {
+  const src = join(root, file);
+  const dest = join(distDir, file);
+  if (existsSync(src)) {
+    if (!dryRun) {
+      copyFileSync(src, dest);
+    }
+    log(`  Copied ${file} → dist/`);
+  } else {
+    log(`  Warning: ${file} not found at ${src}`);
+  }
+}
 
-run("npm", cliPublishArgs, { dryRun, label: `npm ${cliPublishArgs.join(" ")}` });
+// Write a new package.json for publishing with empty dependencies.
+// All runtime code (including @vegamo/deepcode-core and its deps) is already
+// bundled into dist/cli.js by esbuild with packages: "bundle".
+const distPackageJson = {
+  name: cliPkg.name,
+  version: version,
+  description: cliPkg.description,
+  license: cliPkg.license,
+  type: "module",
+  main: "cli.js",
+  bin: {
+    deepcode: "cli.js",
+  },
+  files: ["cli.js", "chunks/**", "templates/**", "bundled/**", "README.md", "LICENSE"],
+  engines: cliPkg.engines,
+  dependencies: {},
+};
+
+if (!dryRun) {
+  writeJson(join(distDir, "package.json"), distPackageJson);
+}
+log("  Written dist/package.json with dependencies: {}");
+
+ok("dist/ prepared for publishing");
+
+// ── 7. Publish from dist/ ────────────────────────────────────────────────────
+
+step(8, TOTAL_STEPS, "Publishing @vegamo/deepcode-cli from dist/...");
+
+const publishArgs = ["publish", "--access", "public", "--tag", tag, "--registry", "https://registry.npmjs.org"];
+if (dryRun) publishArgs.push("--dry-run");
+
+run("npm", publishArgs, {
+  dryRun,
+  cwd: distDir,
+  label: `cd dist && npm ${publishArgs.join(" ")}`,
+});
 ok(`Published @vegamo/deepcode-cli@${version}`);
 
-// Restore file:../core for local development
-if (!dryRun) {
-  writeJson(cliPkgPath, JSON.parse(origCliPkg));
-  // But keep the new version
-  const restoredCli = readJson(cliPkgPath);
-  restoredCli.version = version;
-  writeJson(cliPkgPath, restoredCli);
-  log("  Restored @vegamo/deepcode-core dep to file:../core");
-}
-
-// ── 9. Git commit + tag ──────────────────────────────────────────────────────
-
-step(9, TOTAL_STEPS, "Creating git commit and tag...");
+// ── Git commit + tag ─────────────────────────────────────────────────────────
 
 if (!dryRun) {
+  log("\nCreating git commit and tag...");
   run("git", ["add", "packages/core/package.json", "packages/cli/package.json"], {
     label: "git add packages/*/package.json",
   });
@@ -279,8 +289,7 @@ if (!dryRun) {
   });
   ok(`Created commit and tag v${version}`);
 } else {
-  log(`  (dry-run) git add + commit "chore(release): v${version}"`);
-  log(`  (dry-run) git tag v${version}`);
+  log("\n  (dry-run) git add + commit + tag");
 }
 
 // ── Done ─────────────────────────────────────────────────────────────────────
@@ -289,9 +298,8 @@ console.log("\n=========================================");
 console.log(`  🎉  Published v${version} successfully!`);
 console.log("=========================================");
 console.log(`
-  Packages published:
-    • @vegamo/deepcode-core@${version}
-    • @vegamo/deepcode-cli@${version}
+  Package published:
+    • @vegamo/deepcode-cli@${version}  (core bundled, zero runtime dependencies)
 
   Verify:
     npm view @vegamo/deepcode-cli version

--- a/scripts/prepare-vscode.js
+++ b/scripts/prepare-vscode.js
@@ -1,0 +1,260 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, "..");
+
+// Load .env file if VSCE_PAT is not already set
+if (!process.env.VSCE_PAT) {
+  const envPath = join(root, ".env");
+  if (existsSync(envPath)) {
+    const lines = readFileSync(envPath, "utf-8").split("\n");
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const eqIdx = trimmed.indexOf("=");
+      if (eqIdx === -1) continue;
+      const key = trimmed.slice(0, eqIdx).trim();
+      const value = trimmed.slice(eqIdx + 1).trim();
+      if (key && !process.env[key]) {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function log(msg) {
+  console.log(msg);
+}
+
+function step(n, total, msg) {
+  console.log(`\n[${n}/${total}] ${msg}`);
+}
+
+function fail(msg) {
+  console.error(`\n❌  ${msg}`);
+  process.exit(1);
+}
+
+function ok(msg) {
+  console.log(`✅  ${msg}`);
+}
+
+function run(cmd, args, opts = {}) {
+  const label = opts.label ?? `${cmd} ${args.join(" ")}`;
+  if (opts.dryRun) {
+    log(`  (dry-run) ${label}`);
+    return { status: 0, stdout: "" };
+  }
+  const result = spawnSync(cmd, args, {
+    stdio: opts.stdio ?? "inherit",
+    cwd: opts.cwd ?? root,
+    shell: true,
+    env: { ...process.env, ...opts.env },
+  });
+  if (result.status !== 0) {
+    fail(`Command failed: ${label}`);
+  }
+  return result;
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf-8"));
+}
+
+function writeJson(filePath, data) {
+  writeFileSync(filePath, JSON.stringify(data, null, 2) + "\n", "utf-8");
+}
+
+function isValidSemver(v) {
+  return /^\d+\.\d+\.\d+(-[\w.]+)?(\+[\w.]+)?$/.test(v);
+}
+
+// ── Parse args ───────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+let version = null;
+let dryRun = false;
+let force = false;
+
+for (let i = 0; i < args.length; i++) {
+  const arg = args[i];
+  if (arg === "--dry-run") {
+    dryRun = true;
+  } else if (arg === "--force") {
+    force = true;
+  } else if (!version) {
+    version = arg;
+  } else {
+    fail(`Unknown argument: ${arg}`);
+  }
+}
+
+if (!version) {
+  log(`
+Usage: node scripts/prepare-vscode.js <version> [options]
+
+Arguments:
+  <version>          Semver version to publish (e.g. 0.1.32, 0.2.0-beta.1)
+
+Options:
+  --dry-run          Preview all steps without executing
+  --force            Skip branch check (publish from non-main branch)
+
+Environment:
+  VSCE_PAT           Required. Azure DevOps Personal Access Token for marketplace auth.
+                     Generate at: https://dev.azure.com/vegamo/_usersSettings/tokens
+                     Can also be set in .env file (auto-loaded).
+
+Examples:
+  VSCE_PAT=xxx node scripts/prepare-vscode.js 0.1.32
+  node scripts/prepare-vscode.js 0.1.32-beta.1
+  node scripts/prepare-vscode.js 0.1.32 --dry-run
+`);
+  process.exit(1);
+}
+
+if (!isValidSemver(version)) {
+  fail(`Invalid semver version: ${version}`);
+}
+
+const TOTAL_STEPS = 7;
+
+// ── Banner ───────────────────────────────────────────────────────────────────
+
+log("=========================================");
+log(`  Deep Code VSCode — Publish v${version}`);
+log(`  dryRun=${dryRun}  force=${force}`);
+log("=========================================");
+
+// ── 1. Git checks ────────────────────────────────────────────────────────────
+
+step(1, TOTAL_STEPS, "Checking git state...");
+
+const gitStatus = spawnSync("git", ["status", "--porcelain"], {
+  cwd: root,
+  encoding: "utf-8",
+  shell: true,
+});
+if (gitStatus.stdout.trim()) {
+  fail("Working tree is not clean. Commit or stash changes first.");
+}
+ok("Working tree is clean");
+
+if (!force) {
+  const gitBranch = spawnSync("git", ["branch", "--show-current"], {
+    cwd: root,
+    encoding: "utf-8",
+    shell: true,
+  });
+  const branch = gitBranch.stdout.trim();
+  if (branch !== "main") {
+    fail(`Not on main branch (current: ${branch}). Use --force to publish from another branch.`);
+  }
+  ok("On main branch");
+}
+
+// ── 2. VSCE_PAT check ────────────────────────────────────────────────────────
+
+step(2, TOTAL_STEPS, "Checking VSCE_PAT...");
+
+if (!dryRun) {
+  if (!process.env.VSCE_PAT) {
+    fail(
+      "VSCE_PAT environment variable is not set.\n  Generate a Personal Access Token at:\n  https://dev.azure.com/vegamo/_usersSettings/tokens\n  Then: VSCE_PAT=<token> node scripts/prepare-vscode.js <version>"
+    );
+  }
+  ok("VSCE_PAT is set");
+} else {
+  log("  (dry-run) skipping VSCE_PAT check");
+}
+
+// ── 3. Version bump ──────────────────────────────────────────────────────────
+
+step(3, TOTAL_STEPS, "Updating package version...");
+
+const vscodePkgPath = join(root, "packages", "vscode-ide-companion", "package.json");
+
+const vscodePkg = readJson(vscodePkgPath);
+
+const oldVersion = vscodePkg.version;
+
+vscodePkg.version = version;
+
+if (!dryRun) {
+  writeJson(vscodePkgPath, vscodePkg);
+  ok(`Updated packages/vscode-ide-companion: ${oldVersion} → ${version}`);
+} else {
+  log(`  (dry-run) packages/vscode-ide-companion: ${oldVersion} → ${version}`);
+}
+
+// ── 4. Quality checks ────────────────────────────────────────────────────────
+
+step(4, TOTAL_STEPS, "Running quality checks (typecheck + lint + format)...");
+
+run("npm", ["run", "check"], { dryRun });
+ok("All checks passed");
+
+// ── 5. Tests ──────────────────────────────────────────────────────────────────
+
+step(5, TOTAL_STEPS, "Running tests...");
+
+run("npm", ["run", "test", "--workspaces"], { dryRun });
+ok("All tests passed");
+
+// ── 6. Build ──────────────────────────────────────────────────────────────────
+
+step(6, TOTAL_STEPS, "Building VSCode extension...");
+
+run("npm", ["run", "build:vscode"], { dryRun });
+ok("VSCode extension built");
+
+// ── 7. Publish to marketplace ─────────────────────────────────────────────────
+
+step(7, TOTAL_STEPS, "Publishing deepcode-vscode to marketplace...");
+
+const vscodeRoot = join(root, "packages", "vscode-ide-companion");
+const vsceArgs = ["vsce", "publish", version, "--no-dependencies"];
+if (dryRun) vsceArgs.splice(2, 0, "--dry-run");
+
+run("npx", vsceArgs, {
+  cwd: vscodeRoot,
+  env: { VSCE_PAT: process.env.VSCE_PAT },
+  label: `npx ${vsceArgs.join(" ")}`,
+});
+ok(`Published deepcode-vscode@${version} to marketplace`);
+
+// ── Git commit + tag ─────────────────────────────────────────────────────────
+
+if (!dryRun) {
+  log("\nCreating git commit and tag...");
+  run("git", ["add", "packages/vscode-ide-companion/package.json"], {
+    label: "git add packages/vscode-ide-companion/package.json",
+  });
+  run("git", ["commit", "-m", `chore(release): vscode v${version}`], {
+    label: `git commit -m "chore(release): vscode v${version}"`,
+  });
+  run("git", ["tag", `vscode-v${version}`], {
+    label: `git tag vscode-v${version}`,
+  });
+  ok(`Created commit and tag vscode-v${version}`);
+} else {
+  log("\n  (dry-run) git add + commit + tag");
+}
+
+// ── Done ─────────────────────────────────────────────────────────────────────
+
+console.log("\n=========================================");
+console.log(`  🎉  Published deepcode-vscode@${version} successfully!`);
+console.log("=========================================");
+console.log(`
+  Verify:
+    https://marketplace.visualstudio.com/items?itemName=vegamo.deepcode-vscode
+
+  Push to remote:
+    git push && git push --tags
+`);


### PR DESCRIPTION
## Summary

- 将 CLI 构建改为使用 esbuild 的拆分和代码分块，适配 Node 22 环境
- esbuild 配置中内联 core 包及所有依赖，实现零运行时依赖
- 引入自定义 shims 支持 Node 内置模块和空 shim 替代浏览器专用包
- 修改 copy 脚本，复制 core/templates 至 dist/templates 及 legacy bundled 目录
- 发布脚本重构：只发布单个打包的 CLI 包，不再单独发布 core 包
- 发布时在 dist 写入无依赖的 package.json 并从 dist 目录发布
- 简化发布流程，减少步骤数并更新发布文档说明
- package.json 添加对 react-devtools-core 的开发依赖用于本地开发支持


## 发版流程（现在不需要单独发布 core 包了， core的代码会被打包到 cli 中）

  ### 前置准备（首次）

  #### 创建 .env 文件，填入 VSCode 市场发布 token
  cp .env.example .env
  #### 编辑 .env，填入 VSCE_PAT=你的token

  ### 正式发布

  ##### 1. 统一升级版本号（core + cli + vscode 三个包同步）
  ```
npm run release:version -- patch
```

  ##### 2. 发布 CLI 到 npm（自动 build + 质量检查 + 测试 + commit + tag）
```
  npm run prepare:package -- 0.1.32
```

  ##### 3. 发布 VSCode 扩展到市场（自动 build + 质量检查 + 测试 + commit + tag）
```
  npm run prepare:vscode -- 0.1.32
```

  ##### 4. 推送到远程
```
  git push && git push --tags
```

  ### 预发布（beta）

  ```
npm run release:version -- prerelease --preid beta
  npm run prepare:package -- 0.1.32-beta.0
  npm run prepare:vscode -- 0.1.32-beta.0
  git push && git push --tags
```

  ### 预演（不实际发布）

  ```
npm run prepare:package -- 0.1.32 --dry-run
  npm run prepare:vscode -- 0.1.32 --dry-run
```

  --------
  ### 三个脚本的职责


|        脚本        |          命令           |              发布目标                |      更新版本       |
|------|------|------|------|
|  version.js         |  `npm run release:version`  | 无（只改版本号）                      |  core + cli + vscode  |
|  prepare-package.js  | `npm run prepare:package`  |  npm (@vegamo/deepcode-cli)            |  core + cli          |
|  prepare-vscode.js   | `npm run prepare:vscode`   | VS Code Marketplace (deepcode-vscode)  |  仅 vscode           |
 