### PR TITLE
fix(read): reject fractional PDF page ranges

### DIFF
--- a/packages/core/src/tests/tool-handlers.test.ts
+++ b/packages/core/src/tests/tool-handlers.test.ts
@@ -998,6 +998,22 @@ test("Read returns an acknowledgement for images and attaches the image as a fol
   );
 });
 
+test("Read rejects fractional PDF page ranges", async () => {
+  const workspace = createTempWorkspace();
+  const filePath = path.join(workspace, "sample.pdf");
+  fs.writeFileSync(filePath, makePdfWithPages(4), "utf8");
+
+  for (const pages of ["1.9", "2.1-3.9"]) {
+    const readResult = await handleReadTool(
+      { file_path: filePath, pages },
+      createContext("pdf-fractional-pages", workspace)
+    );
+
+    assert.equal(readResult.ok, false);
+    assert.match(readResult.error ?? "", /must be an integer/);
+  }
+});
+
 function createContext(
   sessionId: string,
   projectRoot: string,
@@ -1022,6 +1038,11 @@ function createTempWorkspace(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "deepcode-tools-"));
   tempDirs.push(dir);
   return dir;
+}
+
+function makePdfWithPages(pageCount: number): string {
+  const pages = Array.from({ length: pageCount }, (_, index) => `${index + 1} 0 obj << /Type /Page >> endobj`);
+  return ["%PDF-1.4", ...pages, "%%EOF", ""].join("\n");
 }
 
 async function readSnippet(

--- a/packages/core/src/tools/read-handler.ts
+++ b/packages/core/src/tools/read-handler.ts
@@ -552,11 +552,13 @@ function parsePositiveInt(value: string, label: string): number {
   if (!Number.isFinite(numeric)) {
     throw new Error(`${label} must be a number.`);
   }
-  const integer = Math.trunc(numeric);
-  if (integer < 1) {
+  if (!Number.isInteger(numeric)) {
+    throw new Error(`${label} must be an integer.`);
+  }
+  if (numeric < 1) {
     throw new Error(`${label} must be >= 1.`);
   }
-  return integer;
+  return numeric;
 }
 
 function readNotebook(filePath: string): string {


### PR DESCRIPTION
## Summary

Reject fractional PDF page ranges instead of silently truncating them.

Before this change, `pages: "1.9"` was accepted as page `1`, and `pages: "2.1-3.9"` was accepted as `2-3`. Page ranges should be positive integers, so fractional values now return a validation error.

## Testing

- `cd packages/core/src/tests && node --import tsx --test tool-handlers.test.ts`
- `npm run format:check -- packages/core/src/tools/read-handler.ts packages/core/src/tests/tool-handlers.test.ts`
- `npm run typecheck --workspace @vegamo/deepcode-core`