### PR TITLE
fix(cli): preserve positional prompt arguments

### DIFF
--- a/packages/cli/src/cli-args.ts
+++ b/packages/cli/src/cli-args.ts
@@ -140,6 +140,8 @@ export async function parseArguments(argv?: string[]): Promise<ParsedCliArgs> {
   });
 
   const parsed = y.parseSync() as Record<string, unknown>;
+  const queryRaw = parsed.query as string | string[] | undefined;
+  const positionalPrompt = Array.isArray(queryRaw) ? queryRaw.join(" ") : queryRaw;
 
   const resumeRaw = parsed.resume as string | undefined;
   let resume: ParsedCliArgs["resume"];
@@ -152,7 +154,7 @@ export async function parseArguments(argv?: string[]): Promise<ParsedCliArgs> {
   }
 
   return {
-    prompt: parsed.prompt as string | undefined,
+    prompt: (parsed.prompt as string | undefined) ?? positionalPrompt,
     resume,
     version: parsed.version === true,
     help: parsed.help === true,

--- a/packages/cli/src/tests/cli-args.test.ts
+++ b/packages/cli/src/tests/cli-args.test.ts
@@ -28,6 +28,18 @@ test("parseArguments returns prompt after --prompt", async () => {
   assert.equal(r.prompt, "hello world");
 });
 
+test("parseArguments returns prompt from positional query", async () => {
+  const r = await parseArguments(["hello world"]);
+  assert.ok(!("message" in r));
+  assert.equal(r.prompt, "hello world");
+});
+
+test("parseArguments joins multi-word positional query", async () => {
+  const r = await parseArguments(["hello", "world"]);
+  assert.ok(!("message" in r));
+  assert.equal(r.prompt, "hello world");
+});
+
 test("parseArguments returns undefined prompt when -p is not present", async () => {
   const r = await parseArguments(["--resume"]);
   assert.ok(!("message" in r));
@@ -140,6 +152,13 @@ test("parseArguments handles -p before --resume <id>", async () => {
   assert.equal(r.prompt, "hello");
 });
 
+test("parseArguments handles --resume <id> combined with positional query", async () => {
+  const r = await parseArguments(["--resume", "0a5cb7a5-c39d-4c39-a11b-05f8b22b8df6", "hello", "again"]);
+  assert.ok(!("message" in r));
+  assert.equal(r.resume, "0a5cb7a5-c39d-4c39-a11b-05f8b22b8df6");
+  assert.equal(r.prompt, "hello again");
+});
+
 test("parseArguments --version takes precedence over --help", async () => {
   const r = await parseArguments(["--version", "--help"]);
   assert.ok(!("message" in r));
@@ -192,6 +211,17 @@ test("parseArguments exits on empty -p value", async () => {
   await withMockedExit(async (exitSpy) => {
     try {
       await parseArguments(["-p", ""]);
+    } catch {
+      /* expected */
+    }
+    assert.ok(exitSpy.calls.length >= 1);
+  });
+});
+
+test("parseArguments exits when positional query is combined with -p", async () => {
+  await withMockedExit(async (exitSpy) => {
+    try {
+      await parseArguments(["hello", "-p", "world"]);
     } catch {
       /* expected */
     }


### PR DESCRIPTION
## Summary
- preserve positional `[query..]` arguments as the initial prompt
- keep `--prompt/-p` behavior unchanged while covering positional conflicts
- add CLI argument tests for positional prompts and resume + positional prompt usage

## Tests
- `node --import tsx --test packages/cli/src/tests/cli-args.test.ts`
- `npm run format:check -- packages/cli/src/cli-args.ts packages/cli/src/tests/cli-args.test.ts`
- `npm run typecheck --workspace @vegamo/deepcode-cli`
- `npm run test --workspace @vegamo/deepcode-cli -- --runInBand`
- `npm run build`
- `node packages/cli/dist/cli.js --version`
- `node packages/cli/dist/cli.js --help`