### PR TITLE
feat: add /usage slash command for DeepSeek API balance

### DIFF
--- a/packages/cli/src/ui/core/slash-commands.ts
+++ b/packages/cli/src/ui/core/slash-commands.ts
@@ -9,6 +9,7 @@ export type SlashCommandKind =
   | "resume"
   | "continue"
   | "undo"
+  | "usage"
   | "mcp"
   | "raw"
   | "exit";
@@ -64,6 +65,12 @@ export const BUILTIN_SLASH_COMMANDS: SlashCommandItem[] = [
     name: "undo",
     label: "/undo",
     description: "Restore code and/or conversation to a previous point",
+  },
+  {
+    kind: "usage",
+    name: "usage",
+    label: "/usage",
+    description: "Show DeepSeek API balance / credits",
   },
   {
     kind: "mcp",

--- a/packages/cli/src/ui/views/App.tsx
+++ b/packages/cli/src/ui/views/App.tsx
@@ -35,6 +35,7 @@ import { resolveCurrentSettings, writeModelConfigSelection } from "@vegamo/deepc
 import { useStatusLine } from "../hooks";
 import type { SessionInfo } from "../statusline";
 import { isCollapsedThinking } from "../core/thinking-state";
+import { BUILTIN_SLASH_COMMANDS, findExactSlashCommand } from "../core/slash-commands";
 import { ANSI_CLEAR_SCREEN } from "../constants";
 import type {
   LlmStreamProgress,
@@ -321,6 +322,78 @@ function App({ projectRoot, initialPrompt, resumeSessionId, onRestart }: AppProp
     [exit, sessionManager]
   );
 
+  const handleUsage = useCallback(async () => {
+    const settings = resolveCurrentSettings(projectRoot);
+    const baseURL = settings.baseURL.toLowerCase();
+    if (!baseURL.includes("api.deepseek.com")) {
+      setErrorLine(`/usage is only compatible with DeepSeek API. Current base URL: ${settings.baseURL}`);
+      return;
+    }
+    if (!settings.apiKey) {
+      setErrorLine("No API key configured. Set DEEPCODE_API_KEY env var or apiKey in settings.json.");
+      return;
+    }
+
+    setBusy(true);
+    setErrorLine(null);
+    try {
+      const response = await fetch("https://api.deepseek.com/user/balance", {
+        headers: { Authorization: `Bearer ${settings.apiKey}` },
+      });
+      if (!response.ok) {
+        setErrorLine(`Failed to fetch balance: HTTP ${response.status} ${response.statusText || ""}`.trim());
+        return;
+      }
+      const data = (await response.json()) as {
+        is_available: boolean;
+        balance_infos?: Array<{
+          currency: string;
+          total_balance: string;
+          granted_balance: string;
+          topped_up_balance: string;
+        }>;
+      };
+
+      const statusIcon = data.is_available ? "🟢" : "🔴";
+      const statusText = data.is_available ? "Available" : "Not available";
+      let content = `/usage\n└ API status: ${statusIcon} ${statusText}`;
+
+      if (data.balance_infos && data.balance_infos.length > 0) {
+        for (const info of data.balance_infos) {
+          content += `\n  ${info.currency}: total ${info.total_balance} (granted ${info.granted_balance}, topped up ${info.topped_up_balance})`;
+        }
+      } else {
+        content += `\n  No balance info returned.`;
+      }
+
+      const now = new Date().toISOString();
+      const activeSessionId = sessionManager.getActiveSessionId();
+      if (activeSessionId) {
+        sessionManager.addSessionSystemMessage(activeSessionId, content, true);
+      } else {
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: crypto.randomUUID(),
+            sessionId: "local",
+            role: "system" as const,
+            content,
+            contentParams: null,
+            messageParams: null,
+            compacted: false,
+            visible: true,
+            createTime: now,
+            updateTime: now,
+          },
+        ]);
+      }
+    } catch (error) {
+      setErrorLine(`Failed to fetch balance: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      setBusy(false);
+    }
+  }, [projectRoot, sessionManager]);
+
   const handlePrompt = useCallback(
     async (submission: PromptSubmission) => {
       if (submission.command === "exit") {
@@ -359,6 +432,10 @@ function App({ projectRoot, initialPrompt, resumeSessionId, onRestart }: AppProp
       if (submission.command === "mcp") {
         setMcpStatuses(sessionManager.getMcpStatus());
         navigateToSubView("mcp-status");
+        return;
+      }
+      if (submission.command === "usage") {
+        void handleUsage();
         return;
       }
 
@@ -420,6 +497,7 @@ function App({ projectRoot, initialPrompt, resumeSessionId, onRestart }: AppProp
       sessionManager,
       pendingPermissionReply,
       handleExit,
+      handleUsage,
       onRestart,
       refreshSkills,
       refreshSessionsList,
@@ -551,10 +629,15 @@ function App({ projectRoot, initialPrompt, resumeSessionId, onRestart }: AppProp
       // Step 2: Submit prompt if provided
       if (initialPrompt && initialPrompt.trim()) {
         initialPromptSubmittedRef.current = true;
+        const trimmed = initialPrompt.trim();
+        const slashToken = trimmed.split(/\s+/, 1)[0];
+        const match = findExactSlashCommand(BUILTIN_SLASH_COMMANDS, slashToken);
+        const command = match && match.kind !== "skill" ? (match.kind as PromptSubmission["command"]) : undefined;
         handleSubmit({
-          text: initialPrompt,
+          text: trimmed,
           imageUrls: [],
           selectedSkills: undefined,
+          command,
         });
       }
     }

--- a/packages/cli/src/ui/views/PromptInput.tsx
+++ b/packages/cli/src/ui/views/PromptInput.tsx
@@ -72,7 +72,7 @@ export type PromptSubmission = {
   selectedSkills?: SkillInfo[];
   permissions?: UserToolPermission[];
   alwaysAllows?: PermissionScope[];
-  command?: "new" | "resume" | "continue" | "undo" | "mcp" | "exit";
+  command?: "new" | "resume" | "continue" | "undo" | "usage" | "mcp" | "exit";
 };
 
 export type PromptDraft = {
@@ -705,6 +705,11 @@ export const PromptInput = React.memo(function PromptInput({
     }
     if (item.kind === "undo") {
       onSubmit({ text: "/undo", imageUrls: [], command: "undo" });
+      resetPromptInput();
+      return;
+    }
+    if (item.kind === "usage") {
+      onSubmit({ text: "/usage", imageUrls: [], command: "usage" });
       resetPromptInput();
       return;
     }


### PR DESCRIPTION
# feat: add /usage slash command for DeepSeek API balance

## Summary

Add a `/usage` slash command that queries the DeepSeek API (`GET /user/balance`) and displays the user's credit balance and availability status as a system message in the conversation.

## Motivation

DeepSeek API users with prepaid credits have to visit the DeepSeek website to check their balance. This command brings that information directly into the CLI, saving time and context-switching. It also detects non-DeepSeek providers and shows a clear error instead of failing silently.

## Design

### Provider detection

Uses `baseURL` (not model name) to detect DeepSeek:

- `baseURL.includes("api.deepseek.com")` → calls `GET https://api.deepseek.com/user/balance`
- Any other provider → shows error message with current base URL

This is more reliable than model name detection since users may use custom models with the DeepSeek API or vice versa.

### API call

```typescript
const response = await fetch("https://api.deepseek.com/user/balance", {
  headers: { Authorization: `Bearer ${apiKey}` },
});
```

Response format:
```json
{
  "is_available": true,
  "balance_infos": [
    {
      "currency": "USD",
      "total_balance": "9.18",
      "granted_balance": "0.00",
      "topped_up_balance": "9.18"
    }
  ]
}
```

### Display

Result is shown as a system message in the conversation:

```
/usage
└ API status: 🟢 Available
  USD: total 9.18 (granted 0.00, topped up 9.18)
```

If unavailable:
```
/usage
└ API status: 🔴 Not available
  USD: total 9.18 (granted 0.00, topped up 9.18)
```

### Error handling

| Scenario | Behavior |
|---|---|
| Non-DeepSeek provider | `setErrorLine("... only compatible with DeepSeek API ...")` |
| No API key configured | `setErrorLine("No API key configured ...")` |
| HTTP error from API | `setErrorLine("Failed to fetch balance: HTTP <status>")` |
| Network error | `setErrorLine("Failed to fetch balance: <message>")` |

### CLI integration

- Works from the slash command menu (`/usage`)
- Works from `-p` flag: `deepcode-cli -p "/usage"`
- Native `fetch` (Node >= 22, zero dependencies)

## Files Changed

| File | Description |
|------|-------------|
| `packages/cli/src/ui/core/slash-commands.ts` | +7 — `"usage"` kind in type union + built-in command entry |
| `packages/cli/src/ui/views/PromptInput.tsx` | +7 — `"usage"` in `PromptSubmission.command` union + `handleSlashSelection` case |
| `packages/cli/src/ui/views/App.tsx` | +85 — `handleUsage` callback (API call, formatting, display) + `case "usage"` in `handlePrompt` + slash detection in startup effect for `-p` flag |

## Verification

```
npm run check     — typecheck 0 errors, lint 0 errors (1 pre-existing warning), format clean
npm test          — 49 tests, 0 fail
npm run build     — successful
```

Tested with real DeepSeek API key: balance displayed correctly with currency, granted/topped-up breakdown, and availability status.
