### PR TITLE
feat: add /usage slash command for DeepSeek API balance

### DIFF
--- a/packages/cli/src/tests/slash-commands.test.ts
+++ b/packages/cli/src/tests/slash-commands.test.ts
@@ -27,6 +27,7 @@ test("buildSlashCommands prefixes skills before built-ins", () => {
     "resume",
     "continue",
     "undo",
+    "usage",
     "mcp",
     "raw",
     "exit",

--- a/packages/cli/src/ui/core/slash-commands.ts
+++ b/packages/cli/src/ui/core/slash-commands.ts
@@ -9,6 +9,7 @@ export type SlashCommandKind =
   | "resume"
   | "continue"
   | "undo"
+  | "usage"
   | "mcp"
   | "raw"
   | "exit";
@@ -64,6 +65,12 @@ export const BUILTIN_SLASH_COMMANDS: SlashCommandItem[] = [
     name: "undo",
     label: "/undo",
     description: "Restore code and/or conversation to a previous point",
+  },
+  {
+    kind: "usage",
+    name: "usage",
+    label: "/usage",
+    description: "Show DeepSeek API balance / credits",
   },
   {
     kind: "mcp",

--- a/packages/cli/src/ui/views/App.tsx
+++ b/packages/cli/src/ui/views/App.tsx
@@ -35,6 +35,7 @@ import { resolveCurrentSettings, writeModelConfigSelection } from "@vegamo/deepc
 import { useStatusLine } from "../hooks";
 import type { SessionInfo } from "../statusline";
 import { isCollapsedThinking } from "../core/thinking-state";
+import { BUILTIN_SLASH_COMMANDS, findExactSlashCommand } from "../core/slash-commands";
 import { ANSI_CLEAR_SCREEN } from "../constants";
 import type {
   LlmStreamProgress,
@@ -321,6 +322,78 @@ function App({ projectRoot, initialPrompt, resumeSessionId, onRestart }: AppProp
     [exit, sessionManager]
   );
 
+  const handleUsage = useCallback(async () => {
+    const settings = resolveCurrentSettings(projectRoot);
+    const baseURL = settings.baseURL.toLowerCase();
+    if (!baseURL.includes("api.deepseek.com")) {
+      setErrorLine(`/usage is only compatible with DeepSeek API. Current base URL: ${settings.baseURL}`);
+      return;
+    }
+    if (!settings.apiKey) {
+      setErrorLine("No API key configured. Set DEEPCODE_API_KEY env var or apiKey in settings.json.");
+      return;
+    }
+
+    setBusy(true);
+    setErrorLine(null);
+    try {
+      const response = await fetch("https://api.deepseek.com/user/balance", {
+        headers: { Authorization: `Bearer ${settings.apiKey}` },
+      });
+      if (!response.ok) {
+        setErrorLine(`Failed to fetch balance: HTTP ${response.status} ${response.statusText || ""}`.trim());
+        return;
+      }
+      const data = (await response.json()) as {
+        is_available: boolean;
+        balance_infos?: Array<{
+          currency: string;
+          total_balance: string;
+          granted_balance: string;
+          topped_up_balance: string;
+        }>;
+      };
+
+      const statusIcon = data.is_available ? "🟢" : "🔴";
+      const statusText = data.is_available ? "Available" : "Not available";
+      let content = `/usage\n└ API status: ${statusIcon} ${statusText}`;
+
+      if (data.balance_infos && data.balance_infos.length > 0) {
+        for (const info of data.balance_infos) {
+          content += `\n  ${info.currency}: total ${info.total_balance} (granted ${info.granted_balance}, topped up ${info.topped_up_balance})`;
+        }
+      } else {
+        content += `\n  No balance info returned.`;
+      }
+
+      const now = new Date().toISOString();
+      const activeSessionId = sessionManager.getActiveSessionId();
+      if (activeSessionId) {
+        sessionManager.addSessionSystemMessage(activeSessionId, content, true);
+      } else {
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: crypto.randomUUID(),
+            sessionId: "local",
+            role: "system" as const,
+            content,
+            contentParams: null,
+            messageParams: null,
+            compacted: false,
+            visible: true,
+            createTime: now,
+            updateTime: now,
+          },
+        ]);
+      }
+    } catch (error) {
+      setErrorLine(`Failed to fetch balance: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      setBusy(false);
+    }
+  }, [projectRoot, sessionManager]);
+
   const handlePrompt = useCallback(
     async (submission: PromptSubmission) => {
       if (submission.command === "exit") {
@@ -359,6 +432,10 @@ function App({ projectRoot, initialPrompt, resumeSessionId, onRestart }: AppProp
       if (submission.command === "mcp") {
         setMcpStatuses(sessionManager.getMcpStatus());
         navigateToSubView("mcp-status");
+        return;
+      }
+      if (submission.command === "usage") {
+        void handleUsage();
         return;
       }
 
@@ -420,6 +497,7 @@ function App({ projectRoot, initialPrompt, resumeSessionId, onRestart }: AppProp
       sessionManager,
       pendingPermissionReply,
       handleExit,
+      handleUsage,
       onRestart,
       refreshSkills,
       refreshSessionsList,
@@ -551,10 +629,15 @@ function App({ projectRoot, initialPrompt, resumeSessionId, onRestart }: AppProp
       // Step 2: Submit prompt if provided
       if (initialPrompt && initialPrompt.trim()) {
         initialPromptSubmittedRef.current = true;
+        const trimmed = initialPrompt.trim();
+        const slashToken = trimmed.split(/\s+/, 1)[0];
+        const match = findExactSlashCommand(BUILTIN_SLASH_COMMANDS, slashToken);
+        const command = match && match.kind !== "skill" ? (match.kind as PromptSubmission["command"]) : undefined;
         handleSubmit({
-          text: initialPrompt,
+          text: trimmed,
           imageUrls: [],
           selectedSkills: undefined,
+          command,
         });
       }
     }

--- a/packages/cli/src/ui/views/App.tsx
+++ b/packages/cli/src/ui/views/App.tsx
@@ -13,6 +13,7 @@ import { findExpandedThinkingId } from "../core/thinking-state";
 import { WelcomeScreen } from "./WelcomeScreen";
 import { AskUserQuestionPrompt } from "./AskUserQuestionPrompt";
 import { McpStatusList } from "./McpStatusList";
+import { UsageView, type UsageData } from "./UsageView";
 import { ProcessStdoutView } from "./ProcessStdoutView";
 import {
   type AskUserQuestionAnswers,
@@ -51,7 +52,7 @@ import { SessionManager } from "@vegamo/deepcode-core";
 import { getCompactPromptTokenThreshold } from "@vegamo/deepcode-core";
 import { writeStdout, writeStdoutLine } from "../../utils/stdio-helpers";
 
-type View = "chat" | "session-list" | "undo" | "mcp-status";
+type View = "chat" | "session-list" | "undo" | "usage" | "mcp-status";
 
 const STATUS_SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
@@ -133,6 +134,7 @@ function App({ projectRoot, initialPrompt, resumeSessionId, onRestart }: AppProp
   const [resolvedSettings, setResolvedSettings] = useState(() => resolveCurrentSettings(projectRoot));
   const [nowTick, setNowTick] = useState(0);
   const [mcpStatuses, setMcpStatuses] = useState<ReturnType<typeof sessionManager.getMcpStatus>>([]);
+  const [usageData, setUsageData] = useState<UsageData | null>(null);
   const [showProcessStdout, setShowProcessStdout] = useState(false);
 
   rawModeRef.current = mode;
@@ -344,55 +346,15 @@ function App({ projectRoot, initialPrompt, resumeSessionId, onRestart }: AppProp
         setErrorLine(`Failed to fetch balance: HTTP ${response.status} ${response.statusText || ""}`.trim());
         return;
       }
-      const data = (await response.json()) as {
-        is_available: boolean;
-        balance_infos?: Array<{
-          currency: string;
-          total_balance: string;
-          granted_balance: string;
-          topped_up_balance: string;
-        }>;
-      };
-
-      const statusIcon = data.is_available ? "🟢" : "🔴";
-      const statusText = data.is_available ? "Available" : "Not available";
-      let content = `/usage\n└ API status: ${statusIcon} ${statusText}`;
-
-      if (data.balance_infos && data.balance_infos.length > 0) {
-        for (const info of data.balance_infos) {
-          content += `\n  ${info.currency}: total ${info.total_balance} (granted ${info.granted_balance}, topped up ${info.topped_up_balance})`;
-        }
-      } else {
-        content += `\n  No balance info returned.`;
-      }
-
-      const now = new Date().toISOString();
-      const activeSessionId = sessionManager.getActiveSessionId();
-      if (activeSessionId) {
-        sessionManager.addSessionSystemMessage(activeSessionId, content, true);
-      } else {
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: crypto.randomUUID(),
-            sessionId: "local",
-            role: "system" as const,
-            content,
-            contentParams: null,
-            messageParams: null,
-            compacted: false,
-            visible: true,
-            createTime: now,
-            updateTime: now,
-          },
-        ]);
-      }
+      const data: UsageData = await response.json();
+      setUsageData(data);
+      navigateToSubView("usage");
     } catch (error) {
       setErrorLine(`Failed to fetch balance: ${error instanceof Error ? error.message : String(error)}`);
     } finally {
       setBusy(false);
     }
-  }, [projectRoot, sessionManager]);
+  }, [projectRoot, navigateToSubView]);
 
   const handlePrompt = useCallback(
     async (submission: PromptSubmission) => {
@@ -1032,6 +994,8 @@ function App({ projectRoot, initialPrompt, resumeSessionId, onRestart }: AppProp
             void sessionManager.reconnectMcpServer(name, latest.mcpServers?.[name]);
           }}
         />
+      ) : view === "usage" ? (
+        <UsageView data={usageData ?? { is_available: false, balance_infos: [] }} onCancel={() => setView("chat")} />
       ) : shouldShowQuestionPrompt && pendingQuestion && !busy ? (
         <AskUserQuestionPrompt
           questions={pendingQuestion.questions}

--- a/packages/cli/src/ui/views/PromptInput.tsx
+++ b/packages/cli/src/ui/views/PromptInput.tsx
@@ -72,7 +72,7 @@ export type PromptSubmission = {
   selectedSkills?: SkillInfo[];
   permissions?: UserToolPermission[];
   alwaysAllows?: PermissionScope[];
-  command?: "new" | "resume" | "continue" | "undo" | "mcp" | "exit";
+  command?: "new" | "resume" | "continue" | "undo" | "usage" | "mcp" | "exit";
 };
 
 export type PromptDraft = {
@@ -705,6 +705,11 @@ export const PromptInput = React.memo(function PromptInput({
     }
     if (item.kind === "undo") {
       onSubmit({ text: "/undo", imageUrls: [], command: "undo" });
+      resetPromptInput();
+      return;
+    }
+    if (item.kind === "usage") {
+      onSubmit({ text: "/usage", imageUrls: [], command: "usage" });
       resetPromptInput();
       return;
     }

--- a/packages/cli/src/ui/views/UsageView.tsx
+++ b/packages/cli/src/ui/views/UsageView.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { Box, Text, useInput } from "ink";
+
+export type UsageData = {
+  is_available: boolean;
+  balance_infos: Array<{
+    currency: string;
+    total_balance: string;
+    granted_balance: string;
+    topped_up_balance: string;
+  }>;
+};
+
+type Props = {
+  data: UsageData;
+  onCancel: () => void;
+};
+
+export function UsageView({ data, onCancel }: Props): React.ReactElement {
+  useInput((_input, key) => {
+    if (key.escape) {
+      onCancel();
+    }
+  });
+
+  return (
+    <Box flexDirection="column" marginLeft={1} paddingX={1} gap={1} borderStyle="round" borderDimColor>
+      <Box flexDirection="column">
+        <Text color="#229ac3" bold>
+          /usage{" "}
+          <Text color={data.is_available ? "green" : "red"}>
+            {data.is_available ? "🟢 Available" : "🔴 Not available"}
+          </Text>
+        </Text>
+      </Box>
+      {data.balance_infos.length > 0 ? (
+        <Box flexDirection="column">
+          {data.balance_infos.map((info, i) => (
+            <Text key={i}>
+              <Text bold>{info.currency}</Text>
+              {"  total "}
+              <Text bold>{info.total_balance}</Text>
+              {"  (granted "}
+              {info.granted_balance}
+              {", topped up "}
+              {info.topped_up_balance}
+              {")"}
+            </Text>
+          ))}
+        </Box>
+      ) : (
+        <Box>
+          <Text dimColor>No balance info returned.</Text>
+        </Box>
+      )}
+      <Text dimColor>Esc to close</Text>
+    </Box>
+  );
+}


### PR DESCRIPTION
# Summary

Add a `/usage` slash command that queries the DeepSeek API (`GET /user/balance`) and displays the user's credit balance and availability status in a dedicated bordered view.

## Motivation

DeepSeek API users with prepaid credits have to visit the DeepSeek website to check their balance. This command brings that information directly into the CLI.

## Design

The command opens a bordered view (same pattern as `/mcp` status). Press `Esc` to return to chat.

### Provider detection

- `baseURL.includes("api.deepseek.com")` → calls `GET https://api.deepseek.com/user/balance`
- Any other provider → shows error with current base URL

### Error handling

| Scenario | Behavior |
|---|---|
| Non-DeepSeek provider | `setErrorLine` with base URL |
| No API key configured | `setErrorLine` |
| HTTP error from API | `setErrorLine` with status |
| Network error | `setErrorLine` with message |

## Files Changed

| File | Description |
|------|-------------|
| `packages/cli/src/ui/views/UsageView.tsx` | **New** -- bordered view component (+59) |
| `packages/cli/src/ui/core/slash-commands.ts` | +7 -- `"usage"` kind + built-in entry |
| `packages/cli/src/ui/views/App.tsx` | +49/-2 -- `handleUsage` callback + view routing |
| `packages/cli/src/ui/views/PromptInput.tsx` | +6/-1 -- command union type + handler |
| `packages/cli/src/tests/slash-commands.test.ts` | +1 -- built-in names assertion |

## Verification

```
npm run check     -- typecheck 0 errors, lint 0 errors, format clean
npm test          -- all tests pass
npm run build     -- successful
```