### PR TITLE
fix(session): remove interrupted message in user's dialog history

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -1661,7 +1661,7 @@ ${agentInstructions}
       contentParts.push(`Failed to kill processes: ${failedPids.join(", ")}.`);
     }
 
-    this.onAssistantMessage(this.buildUserMessage(sessionId, { text: contentParts.join(" ") }), false);
+    this.onAssistantMessage(this.buildSystemMessage(sessionId, contentParts.join(" ")), false);
   }
 
   private isInterrupted(sessionId: string): boolean {


### PR DESCRIPTION
### 问题描述

当输入Ctrl + C 或者 Esc 打断对话后，终端打印的提示信息 “Interrupted.”，是通过 buildUserMessage 构造消息，会污染用户输入历史。

用户再通过方向键调整，想修改上一次的输入，就会需要多一次的向上操作。

### 改动点

改为 buildSystemMessage 构造一条不影响的 system 消息。

### 版本

0.1.33

### 效果

前

<img width="1618" height="339" alt="图片" src="https://github.com/user-attachments/assets/f315b3c1-17ad-4529-bca9-c63826160621" />

后

<img width="2213" height="501" alt="图片" src="https://github.com/user-attachments/assets/f82d9835-b4a0-4a67-9285-237570e4baa0" />