### PR TITLE
docs: add Parallel Search MCP example

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -84,6 +84,21 @@ MCP 工具在 Deep Code 中的命名格式为 `mcp__<服务名>__<工具名>`，
 }
 ```
 
+### Parallel Search
+
+通过 `web_search` 和 `web_fetch` 工具提供实时网页搜索和 URL 内容提取。默认端点无需账户或 API Key；`mcp-remote` 会将远程 Streamable HTTP 服务器桥接为 stdio：
+
+```json
+{
+  "mcpServers": {
+    "parallel-search": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://search.parallel.ai/mcp"]
+    }
+  }
+}
+```
+
 ### 文件系统
 
 让 Deep Code 在指定目录中读写文件：

--- a/docs/mcp_en.md
+++ b/docs/mcp_en.md
@@ -84,6 +84,21 @@ Lets Deep Code control a browser for screenshots, page interactions, etc.:
 }
 ```
 
+### Parallel Search
+
+Adds live web search and URL fetching with the `web_search` and `web_fetch` tools. The default endpoint requires no account or API key; `mcp-remote` bridges the remote Streamable HTTP server to stdio:
+
+```json
+{
+  "mcpServers": {
+    "parallel-search": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://search.parallel.ai/mcp"]
+    }
+  }
+}
+```
+
 ### File System
 
 Enables Deep Code to read and write files within a specified directory:


### PR DESCRIPTION
Deep Code users can already extend the CLI through MCP, so the setup guides are a natural place to show a credential-free web search option. This adds the same copyable configuration to both language versions of the guide and leaves the built-in Web Search unchanged.

## What changed

- Added Parallel Search MCP examples to the Chinese and English MCP guides.
- Used `mcp-remote` with Deep Code's existing stdio configuration path.

## Validation

- Parsed both new JSON examples and verified their command, arguments, and endpoint.
- Checked bilingual parity, changed-file scope, and `git diff --check`.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.