### PR TITLE
fix: add User-Agent header to OpenAI client fetch (#177)

### DIFF
--- a/packages/core/src/common/openai-client.ts
+++ b/packages/core/src/common/openai-client.ts
@@ -3,6 +3,7 @@ import * as os from "os";
 import * as path from "path";
 import OpenAI from "openai";
 import { Agent, fetch as undiciFetch } from "undici";
+import type { HeadersInit } from "undici";
 import { resolveCurrentSettings } from "../settings";
 
 // Custom undici Agent with a 180-second keepAlive timeout.  The default
@@ -11,6 +12,19 @@ import { resolveCurrentSettings } from "../settings";
 // output between prompts.  By passing a dedicated Agent to undiciFetch we
 // keep connections reusable for three minutes after the last request.
 const keepAliveAgent = new Agent({ keepAliveTimeout: 180_000 });
+
+const DEFAULT_USER_AGENT = `deepcode-cli (Node.js ${process.version})`;
+
+// Inject a default User-Agent header into outgoing requests. Some CDNs and
+// WAFs (e.g. Cloudflare) block requests that arrive without a User-Agent as a
+// basic anti-bot measure. (#177)
+export function buildClientHeaders(initHeaders?: HeadersInit): Headers {
+  const headers = new Headers(initHeaders);
+  if (!headers.has("User-Agent")) {
+    headers.set("User-Agent", DEFAULT_USER_AGENT);
+  }
+  return headers;
+}
 
 // Module-level cache for the OpenAI client instance.  The client itself is
 // a stateless fetch wrapper, so it is safe to share across calls as long as
@@ -73,7 +87,8 @@ export function createOpenAIClient(projectRoot: string = process.cwd()): {
     apiKey: settings.apiKey,
     baseURL: settings.baseURL || undefined,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    fetch: (url: any, init: any) => undiciFetch(url, { ...init, dispatcher: keepAliveAgent }),
+    fetch: (url: any, init: any) =>
+      undiciFetch(url, { ...init, headers: buildClientHeaders(init?.headers), dispatcher: keepAliveAgent }),
   });
   cachedOpenAIKey = cacheKey;
 

--- a/packages/core/src/tests/openai-client.test.ts
+++ b/packages/core/src/tests/openai-client.test.ts
@@ -13,9 +13,8 @@ test("buildClientHeaders preserves existing headers and a custom User-Agent", ()
   assert.equal(headers.get("User-Agent"), "custom-agent");
 });
 
-test("buildClientHeaders accepts a Headers instance and keeps its entries", () => {
-  const source = new Headers({ "Content-Type": "application/json" });
-  const headers = buildClientHeaders(source);
+test("buildClientHeaders accepts tuple-array headers and keeps its entries", () => {
+  const headers = buildClientHeaders([["Content-Type", "application/json"]]);
   assert.equal(headers.get("Content-Type"), "application/json");
   assert.match(headers.get("User-Agent") ?? "", /^deepcode-cli /);
 });

--- a/packages/core/src/tests/openai-client.test.ts
+++ b/packages/core/src/tests/openai-client.test.ts
@@ -1,0 +1,21 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildClientHeaders } from "../common/openai-client";
+
+test("buildClientHeaders injects a default User-Agent when none is set", () => {
+  const headers = buildClientHeaders(undefined);
+  assert.match(headers.get("User-Agent") ?? "", /^deepcode-cli \(Node\.js v\d+\.\d+\.\d+\)$/);
+});
+
+test("buildClientHeaders preserves existing headers and a custom User-Agent", () => {
+  const headers = buildClientHeaders({ Authorization: "Bearer sk-test", "User-Agent": "custom-agent" });
+  assert.equal(headers.get("Authorization"), "Bearer sk-test");
+  assert.equal(headers.get("User-Agent"), "custom-agent");
+});
+
+test("buildClientHeaders accepts a Headers instance and keeps its entries", () => {
+  const source = new Headers({ "Content-Type": "application/json" });
+  const headers = buildClientHeaders(source);
+  assert.equal(headers.get("Content-Type"), "application/json");
+  assert.match(headers.get("User-Agent") ?? "", /^deepcode-cli /);
+});


### PR DESCRIPTION
## Summary

- Adds a default `User-Agent` header to outgoing OpenAI API requests.
- Fixes `403 Your request was blocked` errors from CDNs/WAFs (e.g. Cloudflare) that reject requests without a `User-Agent`.

## Why

Custom/proxy API endpoints routed through Cloudflare or enterprise WAFs block requests arriving without a `User-Agent` as a basic anti-bot measure. The undici fetch wrapper used by the OpenAI client never set one, so those setups failed immediately with 403.

## Changes

- `packages/core/src/common/openai-client.ts`: add `buildClientHeaders()` which injects `deepcode-cli (Node.js <version>)` unless the caller already provided a header, and use it in the fetch wrapper.
- `packages/core/src/tests/openai-client.test.ts`: unit tests for header injection/preservation.

## Validation

- `npm run typecheck` ✅
- `npm test` — new openai-client tests pass ✅

Closes #177
