### PR TITLE
fix(websearch): run .bat custom scripts via shell on Windows (#190)

### DIFF
--- a/packages/core/src/tests/web-search-handler.test.ts
+++ b/packages/core/src/tests/web-search-handler.test.ts
@@ -144,6 +144,17 @@ test("WebSearch returns a configuration error when neither a script nor an LLM c
   );
 });
 
+test("WebSearch executes a configured .bat script on Windows", { skip: process.platform !== "win32" }, async () => {
+  const workspace = createTempWorkspace();
+  const scriptPath = path.join(workspace, "web-search.bat");
+  fs.writeFileSync(scriptPath, "@echo off\r\necho query=%1\r\n", "utf8");
+
+  const result = await handleWebSearchTool({ query: "test" }, createContext(workspace, { webSearchTool: scriptPath }));
+
+  assert.equal(result.ok, true);
+  assert.match(result.output ?? "", /query=test/);
+});
+
 function createContext(
   projectRoot: string,
   options: {

--- a/packages/core/src/tools/web-search-handler.ts
+++ b/packages/core/src/tools/web-search-handler.ts
@@ -159,6 +159,10 @@ async function runWebSearchScript(
   return new Promise((resolve) => {
     const child = spawn(scriptPath, [query], {
       cwd: context.projectRoot,
+      // Node.js v20+ removed the automatic cmd.exe routing for .bat/.cmd
+      // files on Windows, so custom webSearchTool scripts pointing at .bat
+      // files need an explicit shell. (#190)
+      shell: process.platform === "win32",
       env: { ...process.env, ...configuredEnv },
       stdio: ["ignore", "pipe", "pipe"],
     });


### PR DESCRIPTION
## Summary

- Custom `webSearchTool` scripts pointing at `.bat` files now run on Windows instead of failing with `spawn EINVAL`.

## Why

Node.js v20+ removed the automatic `cmd.exe` routing for `.bat`/`.cmd` files, so `child_process.spawn` of a `.bat` path throws `EINVAL` on Windows. This broke the configured web-search script path for Windows users.

## Changes

- `packages/core/src/tools/web-search-handler.ts`: pass `shell: process.platform === "win32"` to `spawn` so `.bat` scripts execute through `cmd.exe` on Windows only (POSIX behavior unchanged).
- `packages/core/src/tests/web-search-handler.test.ts`: Windows-only test running a `.bat` script (skipped elsewhere).

## Validation

- `npm run typecheck` ✅
- `npm test` — existing web-search tests still pass; new `.bat` test runs on Windows ✅

Closes #190
