### PR TITLE
fix(settings): scaffold settings.json template on first run (#202)

### DIFF
--- a/packages/cli/src/cli.tsx
+++ b/packages/cli/src/cli.tsx
@@ -2,7 +2,7 @@ import { render } from "ink";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
-import { setShellIfWindows, getProjectCode } from "@vegamo/deepcode-core";
+import { ensureUserSettingsFile, getProjectCode, setShellIfWindows } from "@vegamo/deepcode-core";
 import { checkForNpmUpdate, promptForPendingUpdate } from "./common/update-check";
 import { AppContainer } from "./ui";
 import { parseArguments } from "./cli-args";
@@ -27,6 +27,13 @@ async function main(): Promise<void> {
   // On Windows without Git Bash, setShellIfWindows() throws and calls process.exit(1).
   // If called before argument parsing, --help and --version would fail on those machines.
   configureWindowsShell();
+
+  // First run: scaffold a ready-to-edit settings.json so the user only has to
+  // paste their API key instead of authoring the file by hand. (#202)
+  const scaffold = ensureUserSettingsFile();
+  if (scaffold.created) {
+    writeStderrLine(`Created ${scaffold.path} — edit it to add your API key.\n`);
+  }
 
   let initialPrompt = parsed.prompt;
   let resumeSessionId = parsed.resume;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,7 @@ export {
   getProjectSettingsPath,
   getDefaultContextWindow,
   getDefaultAutoCompactWindow,
+  ensureUserSettingsFile,
   DEFAULT_MODEL,
   DEFAULT_BASE_URL,
 } from "./settings";

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -683,6 +683,34 @@ export function readProjectSettings(projectRoot: string = process.cwd()): Deepco
   return readSettingsFile(getProjectSettingsPath(projectRoot));
 }
 
+export const DEFAULT_SETTINGS_TEMPLATE: DeepcodingSettings = {
+  env: {
+    API_KEY: "",
+    BASE_URL: DEFAULT_BASE_URL,
+    MODEL: DEFAULT_MODEL,
+  },
+};
+
+/**
+ * Create the user settings file on first run with a ready-to-edit template so
+ * the user only has to paste their API key instead of authoring the file and
+ * guessing the schema by hand. Never overwrites an existing file. (#202)
+ */
+export function ensureUserSettingsFile(settingsPath: string = getUserSettingsPath()): {
+  created: boolean;
+  path: string;
+} {
+  if (fs.existsSync(settingsPath)) {
+    return { created: false, path: settingsPath };
+  }
+  try {
+    writeSettingsFile(settingsPath, DEFAULT_SETTINGS_TEMPLATE);
+    return { created: true, path: settingsPath };
+  } catch {
+    return { created: false, path: settingsPath };
+  }
+}
+
 function writeSettingsFile(settingsPath: string, settings: DeepcodingSettings): void {
   fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
   fs.writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, "utf8");

--- a/packages/core/src/tests/settings-and-notify.test.ts
+++ b/packages/core/src/tests/settings-and-notify.test.ts
@@ -8,8 +8,31 @@ import {
   type NotifySpawn,
 } from "../common/notify";
 import { applyModelConfigSelection, resolveSettings, resolveSettingsSources } from "../settings";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { DEFAULT_SETTINGS_TEMPLATE, ensureUserSettingsFile, readSettingsFile } from "../settings";
 
 const TEST_PROCESS_ENV = {};
+
+test("ensureUserSettingsFile scaffolds a template and never overwrites an existing file", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "deepcode-settings-test-"));
+  try {
+    const settingsPath = path.join(dir, "settings.json");
+
+    const first = ensureUserSettingsFile(settingsPath);
+    assert.equal(first.created, true);
+    assert.equal(first.path, settingsPath);
+    assert.deepEqual(readSettingsFile(settingsPath), DEFAULT_SETTINGS_TEMPLATE);
+
+    fs.writeFileSync(settingsPath, JSON.stringify({ model: "custom-model" }), "utf8");
+    const second = ensureUserSettingsFile(settingsPath);
+    assert.equal(second.created, false);
+    assert.deepEqual(readSettingsFile(settingsPath), { model: "custom-model" });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 test("resolveSettings reads top-level thinkingEnabled, notify, and webSearchTool", () => {
   const resolved = resolveSettings(


### PR DESCRIPTION
## Summary

- On first run, Deep Code now creates `~/.deepcode/settings.json` with a ready-to-edit template instead of failing with "API key not found" and forcing the user to author the file from scratch.

## Why

A fresh install never scaffolds `settings.json`: the directory exists but the file does not, so the first prompt fails with `API key not found. Please configure ~/.deepcode/settings.json` — leaving users to guess the schema. This makes onboarding require only pasting their API key.

## Changes

- `packages/core/src/settings.ts`: add `DEFAULT_SETTINGS_TEMPLATE` and `ensureUserSettingsFile()` which creates the file on first run (never overwrites an existing one).
- `packages/core/src/index.ts`: export `ensureUserSettingsFile`.
- `packages/cli/src/cli.tsx`: call it at startup and print `Created <path> — edit it to add your API key.` when scaffolded.
- `packages/core/src/tests/settings-and-notify.test.ts`: tests for scaffolding and no-overwrite behavior.

## Validation

- `npm run typecheck` ✅
- `npm test` — new settings tests pass ✅

Closes #202
