### PR TITLE
fix(read): gate image attachment on model multimodality and size (#181)

### DIFF
--- a/packages/core/src/tests/read-handler.test.ts
+++ b/packages/core/src/tests/read-handler.test.ts
@@ -1,0 +1,71 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import type { ToolExecutionContext } from "../tools/executor";
+import { handleReadTool } from "../tools/read-handler";
+
+const tempDirs: string[] = [];
+
+test.afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+function createContext(projectRoot: string, model: string): ToolExecutionContext {
+  return {
+    sessionId: "read-test",
+    projectRoot,
+    toolCall: {
+      id: "tool-call-id",
+      type: "function",
+      function: {
+        name: "read",
+        arguments: "{}",
+      },
+    },
+    createOpenAIClient: () => ({
+      client: null,
+      model,
+      thinkingEnabled: false,
+    }),
+  };
+}
+
+function createPng(workspace: string): string {
+  const filePath = path.join(workspace, "test.png");
+  fs.writeFileSync(filePath, Buffer.from("fakepngdata", "utf8"));
+  return filePath;
+}
+
+test("read tool does not attach image content for text-only models (#181)", async () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "deepcode-read-"));
+  tempDirs.push(workspace);
+  const filePath = createPng(workspace);
+
+  const result = await handleReadTool({ file_path: filePath }, createContext(workspace, "deepseek-reasoner"));
+
+  assert.equal(result.ok, true);
+  assert.equal(result.followUpMessages, undefined);
+  assert.match(result.output ?? "", /does not support images/);
+});
+
+test("read tool attaches image content for multimodal models (#181)", async () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "deepcode-read-"));
+  tempDirs.push(workspace);
+  const filePath = createPng(workspace);
+
+  const result = await handleReadTool({ file_path: filePath }, createContext(workspace, "gpt-4o"));
+
+  assert.equal(result.ok, true);
+  assert.equal(result.output, "File loaded.");
+  assert.ok(Array.isArray(result.followUpMessages));
+  const contentParams = result.followUpMessages?.[0]?.contentParams as unknown[] | undefined;
+  assert.ok(Array.isArray(contentParams));
+  assert.equal((contentParams[0] as { type?: string }).type, "image_url");
+});

--- a/packages/core/src/tools/read-handler.ts
+++ b/packages/core/src/tools/read-handler.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import ignore from "ignore";
 import type { ToolExecutionContext, ToolExecutionFollowUpMessage, ToolExecutionResult } from "./executor";
 import { readTextFileWithMetadata } from "../common/file-utils";
+import { supportsMultimodal } from "../common/model-capabilities";
 import {
   createFullFileSnippet,
   createSnippet,
@@ -14,6 +15,9 @@ import {
 const DEFAULT_LINE_LIMIT = 2000;
 const MAX_LINE_LENGTH = 2000;
 const LINE_NUMBER_WIDTH = 6;
+// Cap for attaching image payloads (as base64) to the conversation history so
+// a single read cannot add hundreds of thousands of tokens. (#181)
+const MAX_ATTACHED_IMAGE_BYTES = 15 * 1024 * 1024;
 const DEFAULT_GITIGNORE = [
   "node_modules/",
   ".git/",
@@ -179,15 +183,27 @@ export async function handleReadTool(
         timestamp: Math.floor(stat.mtimeMs),
         isPartialView: true,
       });
+      // Gate base64 image inlining on the active model's multimodality and a
+      // size cap so text-only models never accumulate megabytes of base64 in
+      // the conversation history. (#181)
+      const llmContext = context.createOpenAIClient?.();
+      const multimodal = supportsMultimodal(llmContext?.model ?? "");
+      const tooLarge = buffer.length > MAX_ATTACHED_IMAGE_BYTES;
+      const followUpMessages =
+        multimodal && !tooLarge ? [buildImageFollowUpMessage(filePath, mime, buffer)] : undefined;
       return {
         ok: true,
         name: "read",
-        output: "File loaded.",
+        output: !multimodal
+          ? "File loaded (image content not attached: the active model does not support images)."
+          : tooLarge
+            ? `File loaded (image content not attached: file exceeds the ${formatBytes(MAX_ATTACHED_IMAGE_BYTES)} attach limit).`
+            : "File loaded.",
         metadata: {
           mime,
           bytes: buffer.length,
         },
-        followUpMessages: [buildImageFollowUpMessage(filePath, mime, buffer)],
+        followUpMessages,
       };
     }
 
@@ -454,6 +470,16 @@ function getImageMimeType(ext: string): string {
     default:
       return "image/png";
   }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  if (bytes >= 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${bytes} B`;
 }
 
 function buildImageFollowUpMessage(filePath: string, mime: string, buffer: Buffer): ToolExecutionFollowUpMessage {


### PR DESCRIPTION
## Summary

- The `read` tool only attaches image content (base64) to the conversation history when the active model supports multimodal input, and skips files above a size cap.
- Text-only models no longer accumulate megabytes of base64 in history, preventing context overflow (`HTTP 400`) on session resume.

## Why

The `read` tool inlined whole image files as base64 data-URIs into history regardless of the model. On text-only models (e.g. `deepseek-reasoner`) each image added hundreds of thousands of tokens to the stored history; after a few reads or a resume, requests exceeded the context window and hard-failed with 400. Request-time filtering already existed, but the history itself still grew unboundedly.

## Changes

- `packages/core/src/tools/read-handler.ts`: gate image attachment on `supportsMultimodal(model)` and a 15 MB size cap; return a clear notice instead of attaching when gated.
- `packages/core/src/tests/read-handler.test.ts`: tests for text-only (no attach) and multimodal (attach) models.

## Validation

- `npm run typecheck` ✅
- `npm test` — new read-handler tests pass ✅

Closes #181
