### PR TITLE
feat(settings): support enabledSkillsDefaultOff whitelist mode (#178)

### DIFF
--- a/packages/cli/src/tests/exec-runner.test.ts
+++ b/packages/cli/src/tests/exec-runner.test.ts
@@ -33,6 +33,7 @@ function createSettings(
     telemetryEnabled: false,
     permissions,
     enabledSkills: {},
+    enabledSkillsDefaultOff: false,
     statusline: { enabled: false, refreshMs: 1000, separator: " | ", providers: [] },
   };
 }

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -103,6 +103,7 @@ export type PromptToolOptions = {
 
 type DefaultSkillPromptOptions = {
   enabledSkills?: Record<string, boolean>;
+  enabledSkillsDefaultOff?: boolean;
 };
 
 const DEFAULT_SKILL_TEMPLATES = ["karpathy-guidelines.md"];
@@ -161,13 +162,18 @@ function readToolDocs(extensionRoot: string, options: PromptToolOptions = {}): s
 
 function readDefaultSkillDocs(
   extensionRoot: string,
-  enabledSkills: Record<string, boolean> = {}
+  enabledSkills: Record<string, boolean> = {},
+  enabledSkillsDefaultOff = false
 ): Array<{ name: string; content: string }> {
   const skillsDir = path.join(extensionRoot, "templates", "skills");
   return DEFAULT_SKILL_TEMPLATES.map((entry) => {
     const fullPath = path.join(skillsDir, entry);
     const name = path.basename(entry, ".md");
-    if (enabledSkills[name] === false) {
+    // Whitelist mode (#178): when enabledSkillsDefaultOff is set, only skills
+    // explicitly enabled with `true` are injected; otherwise exclude only
+    // skills explicitly disabled with `false`.
+    const excluded = enabledSkillsDefaultOff ? enabledSkills[name] !== true : enabledSkills[name] === false;
+    if (excluded) {
       return null;
     }
     try {
@@ -182,7 +188,7 @@ function readDefaultSkillDocs(
 }
 
 export function getDefaultSkillPrompt(options: DefaultSkillPromptOptions = {}): string {
-  const skillDocs = readDefaultSkillDocs(getExtensionRoot(), options.enabledSkills);
+  const skillDocs = readDefaultSkillDocs(getExtensionRoot(), options.enabledSkills, options.enabledSkillsDefaultOff);
   if (skillDocs.length === 0) {
     return "";
   }

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -370,6 +370,7 @@ export class SessionManager {
     mcpServers?: Record<string, McpServerConfig>;
     permissions?: Required<PermissionSettings>;
     enabledSkills?: Record<string, boolean>;
+    enabledSkillsDefaultOff?: boolean;
   };
   private readonly onAssistantMessage: (message: SessionMessage, shouldConnect: boolean) => void;
   private readonly onSessionEntryUpdated?: (entry: SessionEntry) => void;
@@ -1181,7 +1182,10 @@ ${agentInstructions}
     const systemMessage = this.buildSystemMessage(sessionId, systemPrompt);
     this.appendSessionMessage(sessionId, systemMessage);
 
-    const defaultSkillPrompt = getDefaultSkillPrompt({ enabledSkills: this.getResolvedSettings().enabledSkills });
+    const defaultSkillPrompt = getDefaultSkillPrompt({
+      enabledSkills: this.getResolvedSettings().enabledSkills,
+      enabledSkillsDefaultOff: this.getResolvedSettings().enabledSkillsDefaultOff,
+    });
     if (defaultSkillPrompt) {
       const defaultSkillMessage = this.buildSystemMessage(sessionId, defaultSkillPrompt);
       this.appendSessionMessage(sessionId, defaultSkillMessage);

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -95,6 +95,7 @@ export type DeepcodingSettings = {
   mcpServers?: Record<string, McpServerConfig>;
   permissions?: PermissionSettings;
   enabledSkills?: EnabledSkillsSettings;
+  enabledSkillsDefaultOff?: boolean;
   statusline?: StatusLineSettings;
 };
 
@@ -115,6 +116,7 @@ export type ResolvedDeepcodingSettings = {
   mcpServers?: Record<string, McpServerConfig>;
   permissions: Required<PermissionSettings>;
   enabledSkills: EnabledSkillsSettings;
+  enabledSkillsDefaultOff: boolean;
   statusline: ResolvedStatusLineSettings;
 };
 
@@ -585,6 +587,12 @@ export function resolveSettingsSources(
     trimString(userSettings?.webSearchTool) ||
     "";
 
+  const enabledSkillsDefaultOff =
+    parseBoolean(systemEnv.ENABLED_SKILLS_DEFAULT_OFF) ??
+    parseBoolean(projectSettings?.enabledSkillsDefaultOff) ??
+    parseBoolean(userSettings?.enabledSkillsDefaultOff) ??
+    false;
+
   return {
     env,
     apiKey: trimString(env.API_KEY) || undefined,
@@ -602,6 +610,7 @@ export function resolveSettingsSources(
     mcpServers: mergeMcpServers(userSettings, projectSettings, userEnv, projectEnv, systemEnv),
     permissions: mergePermissions(userSettings, projectSettings),
     enabledSkills: mergeEnabledSkills(userSettings, projectSettings),
+    enabledSkillsDefaultOff,
     statusline: mergeStatusLine(userSettings, projectSettings),
   };
 }

--- a/packages/core/src/tests/prompt.test.ts
+++ b/packages/core/src/tests/prompt.test.ts
@@ -77,6 +77,24 @@ test("getTools includes UpdatePlan with string plan schema", () => {
   assert.equal((tool.function.parameters.properties.plan as { type?: unknown }).type, "string");
 });
 
+test("getDefaultSkillPrompt honors whitelist mode via enabledSkillsDefaultOff (#178)", () => {
+  const name = "karpathy-guidelines";
+  const defaultPrompt = getDefaultSkillPrompt({});
+  const defaultOffPrompt = getDefaultSkillPrompt({ enabledSkillsDefaultOff: true });
+  const explicitOnPrompt = getDefaultSkillPrompt({
+    enabledSkillsDefaultOff: true,
+    enabledSkills: { [name]: true },
+  });
+  const explicitOffPrompt = getDefaultSkillPrompt({ enabledSkills: { [name]: false } });
+
+  assert.equal(defaultOffPrompt.length, 0, "whitelist mode with no enabled skills injects nothing");
+  if (defaultPrompt) {
+    assert.equal(defaultPrompt.includes(name), true, "default mode injects karpathy-guidelines");
+    assert.equal(explicitOnPrompt.includes(name), true, "whitelist mode injects explicitly enabled skill");
+    assert.equal(explicitOffPrompt.length, 0, "explicit false excludes the skill in default mode");
+  }
+});
+
 test("getTools requires bash sideEffects permission scopes", () => {
   const tool = getTools().find((candidate) => candidate.function.name === "bash");
   assert.ok(tool);

--- a/packages/core/src/tests/settings-and-notify.test.ts
+++ b/packages/core/src/tests/settings-and-notify.test.ts
@@ -11,6 +11,22 @@ import { applyModelConfigSelection, resolveSettings, resolveSettingsSources } fr
 
 const TEST_PROCESS_ENV = {};
 
+test("resolveSettings reads enabledSkillsDefaultOff from settings and env (#178)", () => {
+  const resolved = resolveSettings(
+    { enabledSkillsDefaultOff: true, env: { API_KEY: "sk-test" } },
+    { model: "default-model", baseURL: "https://default.example.com" },
+    TEST_PROCESS_ENV
+  );
+  assert.equal(resolved.enabledSkillsDefaultOff, true);
+
+  const fromEnv = resolveSettings(
+    { env: { API_KEY: "sk-test" } },
+    { model: "default-model", baseURL: "https://default.example.com" },
+    { DEEPCODE_ENABLED_SKILLS_DEFAULT_OFF: "true" }
+  );
+  assert.equal(fromEnv.enabledSkillsDefaultOff, true);
+});
+
 test("resolveSettings reads top-level thinkingEnabled, notify, and webSearchTool", () => {
   const resolved = resolveSettings(
     {


### PR DESCRIPTION
## Summary

- New `enabledSkillsDefaultOff` setting (or `DEEPCODE_ENABLED_SKILLS_DEFAULT_OFF` env var) enables whitelist mode: only skills explicitly set to `true` are injected into the system prompt; everything else is off by default.
- Default behavior is unchanged (only explicitly `false` skills are excluded).

## Why

Issue #178: the built-in skills (e.g. `karpathy-guidelines`) are always injected unless individually disabled. Users who want a minimal, opt-in system prompt had no way to flip the default. Whitelist mode gives them full control.

## Changes

- `packages/core/src/settings.ts`: parse `enabledSkillsDefaultOff` (settings + env) into resolved settings.
- `packages/core/src/prompt.ts`: `readDefaultSkillDocs` excludes a skill when `defaultOff ? enabledSkills[name] !== true : enabledSkills[name] === false`; `getDefaultSkillPrompt` threads the flag through.
- `packages/core/src/session.ts`: pass `enabledSkillsDefaultOff` when building the default skill prompt.
- Tests: `prompt.test.ts` (whitelist behavior), `settings-and-notify.test.ts` (resolution + env).

## Validation

- `npm run typecheck` ✅
- `npm test` — new tests pass ✅

Closes #178
