### PR TITLE
docs(mcp): add You.com MCP example

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -84,6 +84,43 @@ MCP 工具在 Deep Code 中的命名格式为 `mcp__<服务名>__<工具名>`，
 }
 ```
 
+### You.com 联网搜索与研究
+
+通过 You.com MCP 服务器接入实时联网搜索、网页内容读取、可引用的多源研究和财经研究工具。`@youdotcom-oss/mcp` 是一个轻量 STDIO 桥接，把本地 MCP 请求转发到托管在 `https://api.you.com/mcp` 的远程服务器；首轮对话后，模型即可看到 `mcp__ydc__you-search` 等工具。
+
+```json
+{
+  "mcpServers": {
+    "ydc": {
+      "command": "npx",
+      "args": ["-y", "@youdotcom-oss/mcp"],
+      "env": {
+        "YDC_API_KEY": "ydc-...",
+        "YDC_ALLOWED_TOOLS": "you-search,you-contents,you-research,you-finance"
+      }
+    }
+  }
+}
+```
+
+如果想先体验联网搜索、不立刻注册账号，可以把 `YDC_PROFILE` 设为 `free`（免账号、免 Key，仅暴露 `you-search`，每天 100 次查询上限）：
+
+```json
+{
+  "mcpServers": {
+    "ydc": {
+      "command": "npx",
+      "args": ["-y", "@youdotcom-oss/mcp"],
+      "env": {
+        "YDC_PROFILE": "free"
+      }
+    }
+  }
+}
+```
+
+> API Key 在 https://you.com/platform 申请；可用工具集与计费规则见 https://you.com/docs/build-with-agents/mcp-server。
+
 ### 文件系统
 
 让 Deep Code 在指定目录中读写文件：

--- a/docs/mcp_en.md
+++ b/docs/mcp_en.md
@@ -84,6 +84,43 @@ Lets Deep Code control a browser for screenshots, page interactions, etc.:
 }
 ```
 
+### You.com Web Search & Research
+
+Connects you to You.com's real-time web search, page content extraction, citable multi-source research, and finance research via the hosted You.com MCP server at `https://api.you.com/mcp`. `@youdotcom-oss/mcp` is a minimal STDIO bridge that forwards local MCP traffic to the remote server. After the first message, the model sees tools such as `mcp__ydc__you-search`.
+
+```json
+{
+  "mcpServers": {
+    "ydc": {
+      "command": "npx",
+      "args": ["-y", "@youdotcom-oss/mcp"],
+      "env": {
+        "YDC_API_KEY": "ydc-...",
+        "YDC_ALLOWED_TOOLS": "you-search,you-contents,you-research,you-finance"
+      }
+    }
+  }
+}
+```
+
+To try web search without signing up first, set `YDC_PROFILE` to `free` (no account, no API key; exposes only `you-search`, capped at 100 queries/day):
+
+```json
+{
+  "mcpServers": {
+    "ydc": {
+      "command": "npx",
+      "args": ["-y", "@youdotcom-oss/mcp"],
+      "env": {
+        "YDC_PROFILE": "free"
+      }
+    }
+  }
+}
+```
+
+> Get an API key at https://you.com/platform; see the full tool list and pricing at https://you.com/docs/build-with-agents/mcp-server.
+
 ### File System
 
 Enables Deep Code to read and write files within a specified directory:


### PR DESCRIPTION
## What changed

- Added You.com MCP examples to the Chinese and English MCP guides (`docs/mcp.md` + `docs/mcp_en.md`).
- Each section shows two configs: a full toolset (`YDC_API_KEY` + `YDC_ALLOWED_TOOLS`) and a keyless free tier (`YDC_PROFILE=free`, search-only, 100 queries/day).
- Used `@youdotcom-oss/mcp` with Deep Code's existing stdio configuration path, matching the pattern in PR #268.

## Validation

- Parsed both new JSON examples and verified their command, arguments, and endpoint.
- Checked bilingual parity, changed-file scope, and `git diff --check`.

## Disclosure

Disclosure: I work at You.com, which operates this MCP endpoint.
