### PR TITLE
feat: Plan Mode 批准方案时支持"清除上下文并实施计划"

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -78,6 +78,7 @@ Skills are discovered from these locations, in priority order:
 | `/fork`          | Fork the current conversation     |
 | `/continue`      | Continue the active conversation or pick one to resume  |
 | `/model`         | Switch model, thinking mode, and reasoning effort       |
+| `/plan`          | Switch the input to Plan Mode                           |
 | `/raw`           | Toggle display mode (Normal / Lite / Raw scrollback)    |
 | `/init`          | Initialize an AGENTS.md file (LLM project instructions) |
 | `/skills`        | List available skills                                   |

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -77,6 +77,7 @@ Skills 会按以下优先级扫描：
 | `/fork`     | 从当前对话创建独立的新会话                    |
 | `/continue` | 继续当前对话，或选择历史对话恢复                 |
 | `/model`    | 切换模型、思考模式和推理强度                   |
+| `/plan`     | 切换到规划模式（Plan Mode）              |
 | `/raw`      | 切换显示模式（Normal / Lite / Raw 滚动回溯） |
 | `/init`     | 初始化 AGENTS.md 文件                 |
 | `/skills`   | 列出可用 skills                      |

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Skills 会按以下优先级扫描：
 | `/fork`     | 从当前对话创建独立的新会话                    |
 | `/continue` | 继续当前对话，或选择历史对话恢复                 |
 | `/model`    | 切换模型、思考模式和推理强度                   |
+| `/plan`     | 切换到规划模式（Plan Mode）              |
 | `/raw`      | 切换显示模式（Normal / Lite / Raw 滚动回溯） |
 | `/init`     | 初始化 AGENTS.md 文件                 |
 | `/skills`   | 列出可用 skills                      |

--- a/docs/plan-mode.md
+++ b/docs/plan-mode.md
@@ -92,8 +92,9 @@ Plan Mode 的核心规则是**只规划，不动手**。例如以下操作是**�
 | **1. implement this plan** | 退出 Plan Mode，自动发送实现指令，让 AI 开始按方案写代码 |
 | **2. stay in Plan mode** | 保持在 Plan Mode，继续修改或完善方案 |
 | **3. switch to Default mode** | 退出 Plan Mode，回到默认模式（不自动开始实现） |
+| **4. clear context and implement this plan** | 派生一个干净的新会话（仅携带系统提示与方案），在全新上下文中开始实现 |
 
-你可以用数字键 `1-3` 直接选择，也可以用 `↑/↓` 移动光标后按 `Enter` 确认。按 `Esc` 等同于选择 "stay in Plan mode"。
+你可以用数字键 `1-4` 直接选择，也可以用 `↑/↓` 移动光标后按 `Enter` 确认。按 `Esc` 等同于选择 "stay in Plan mode"。
 
 ## Plan Mode 与 UpdatePlan 工具的区别
 

--- a/docs/plan-mode.md
+++ b/docs/plan-mode.md
@@ -92,9 +92,9 @@ Plan Mode 的核心规则是**只规划，不动手**。例如以下操作是**�
 | **1. implement this plan** | 退出 Plan Mode，自动发送实现指令，让 AI 开始按方案写代码 |
 | **2. stay in Plan mode** | 保持在 Plan Mode，继续修改或完善方案 |
 | **3. switch to Default mode** | 退出 Plan Mode，回到默认模式（不自动开始实现） |
-| **4. clear context and implement this plan** | 派生一个干净的新会话（仅携带系统提示、运行上下文、AGENTS.md 指令与方案），在全新上下文中开始实现 |
+| **4. clear context and implement this plan** | 以已批准方案启动干净的新会话 |
 
-注意：该选项不会把规划阶段加载的 skills 带入新会话；实现时可按需通过 skill 工具重新加载。
+已批准方案会成为干净会话的第一条用户消息。新会话重新加载当前配置与 AGENTS.md，并通过精简目录重新发现可用 skills，不复制规划对话或完整 skill 内容。工作区不变，源会话可恢复，文件历史可用时继承；两个会话分别标记为 `planned` 和 `implementation`。
 
 你可以用数字键 `1-4` 直接选择，也可以用 `↑/↓` 移动光标后按 `Enter` 确认。按 `Esc` 等同于选择 "stay in Plan mode"。
 

--- a/docs/plan-mode.md
+++ b/docs/plan-mode.md
@@ -92,7 +92,9 @@ Plan Mode 的核心规则是**只规划，不动手**。例如以下操作是**�
 | **1. implement this plan** | 退出 Plan Mode，自动发送实现指令，让 AI 开始按方案写代码 |
 | **2. stay in Plan mode** | 保持在 Plan Mode，继续修改或完善方案 |
 | **3. switch to Default mode** | 退出 Plan Mode，回到默认模式（不自动开始实现） |
-| **4. clear context and implement this plan** | 派生一个干净的新会话（仅携带系统提示与方案），在全新上下文中开始实现 |
+| **4. clear context and implement this plan** | 派生一个干净的新会话（仅携带系统提示、运行上下文、AGENTS.md 指令与方案），在全新上下文中开始实现 |
+
+注意：该选项不会把规划阶段加载的 skills 带入新会话；实现时可按需通过 skill 工具重新加载。
 
 你可以用数字键 `1-4` 直接选择，也可以用 `↑/↓` 移动光标后按 `Enter` 确认。按 `Esc` 等同于选择 "stay in Plan mode"。
 

--- a/docs/plan-mode_en.md
+++ b/docs/plan-mode_en.md
@@ -92,7 +92,9 @@ After the plan is output, Deep Code automatically shows a choice dialog—no ext
 | **1. implement this plan** | Leave Plan Mode and automatically send an implementation prompt so the AI starts coding |
 | **2. stay in Plan mode** | Stay in Plan Mode to continue refining the plan |
 | **3. switch to Default mode** | Leave Plan Mode and return to Default mode without starting implementation |
-| **4. clear context and implement this plan** | Derive a clean new session (carrying only the system prompt and plan) to implement in a fresh context |
+| **4. clear context and implement this plan** | Derive a clean new session (carrying only the system prompt, runtime context, AGENTS.md instructions, and the plan) to implement in a fresh context |
+
+Note: skills loaded during planning are not carried over; implementation can reload them via the skill tool as needed.
 
 You can press `1-4` to select directly, or use `↑/↓` to move the cursor and `Enter` to confirm. Pressing `Esc` is equivalent to choosing "stay in Plan mode."
 

--- a/docs/plan-mode_en.md
+++ b/docs/plan-mode_en.md
@@ -92,9 +92,9 @@ After the plan is output, Deep Code automatically shows a choice dialog—no ext
 | **1. implement this plan** | Leave Plan Mode and automatically send an implementation prompt so the AI starts coding |
 | **2. stay in Plan mode** | Stay in Plan Mode to continue refining the plan |
 | **3. switch to Default mode** | Leave Plan Mode and return to Default mode without starting implementation |
-| **4. clear context and implement this plan** | Derive a clean new session (carrying only the system prompt, runtime context, AGENTS.md instructions, and the plan) to implement in a fresh context |
+| **4. clear context and implement this plan** | Start a fresh session with the approved plan |
 
-Note: skills loaded during planning are not carried over; implementation can reload them via the skill tool as needed.
+The approved plan becomes the fresh session’s first user message. It reloads current configuration and AGENTS.md and rediscovers available skills from a compact catalog, without copying planning dialogue or skill bodies. The workspace stays unchanged, the source remains resumable, file history is inherited when available, and the sessions are marked `planned` and `implementation`.
 
 You can press `1-4` to select directly, or use `↑/↓` to move the cursor and `Enter` to confirm. Pressing `Esc` is equivalent to choosing "stay in Plan mode."
 

--- a/docs/plan-mode_en.md
+++ b/docs/plan-mode_en.md
@@ -92,8 +92,9 @@ After the plan is output, Deep Code automatically shows a choice dialog—no ext
 | **1. implement this plan** | Leave Plan Mode and automatically send an implementation prompt so the AI starts coding |
 | **2. stay in Plan mode** | Stay in Plan Mode to continue refining the plan |
 | **3. switch to Default mode** | Leave Plan Mode and return to Default mode without starting implementation |
+| **4. clear context and implement this plan** | Derive a clean new session (carrying only the system prompt and plan) to implement in a fresh context |
 
-You can press `1-3` to select directly, or use `↑/↓` to move the cursor and `Enter` to confirm. Pressing `Esc` is equivalent to choosing "stay in Plan mode."
+You can press `1-4` to select directly, or use `↑/↓` to move the cursor and `Enter` to confirm. Pressing `Esc` is equivalent to choosing "stay in Plan mode."
 
 ## Plan Mode vs. UpdatePlan Tool
 

--- a/packages/cli/src/tests/exec-runner.test.ts
+++ b/packages/cli/src/tests/exec-runner.test.ts
@@ -147,7 +147,7 @@ function createHarness(scenario: ManagerScenario = {}) {
             },
             true
           );
-          options.onProcessStdout?.(123, "process output\n");
+          options.onProcessStdout?.(123, "process output\n", activeId);
           scenario.duringPrompt?.();
           entry = createEntry(activeId, scenario.finalStatus ?? "completed", {
             assistantReply: scenario.finalReply === undefined ? "final answer" : scenario.finalReply,

--- a/packages/cli/src/tests/prompt-input-keys.test.ts
+++ b/packages/cli/src/tests/prompt-input-keys.test.ts
@@ -185,6 +185,18 @@ test("getPlanImplementationChoice treats escape as staying in Plan Mode", () => 
   assert.equal(getPlanImplementationChoice("", { escape: true, return: false }, 0), "stay");
 });
 
+test("getPlanImplementationChoice maps digit keys 1-4 to the four choices", () => {
+  assert.equal(getPlanImplementationChoice("1", { escape: false, return: false }, 0), "implement");
+  assert.equal(getPlanImplementationChoice("2", { escape: false, return: false }, 0), "stay");
+  assert.equal(getPlanImplementationChoice("3", { escape: false, return: false }, 0), "default");
+  assert.equal(getPlanImplementationChoice("4", { escape: false, return: false }, 0), "clearContext");
+});
+
+test("getPlanImplementationChoice selects the choice at the cursor on return", () => {
+  assert.equal(getPlanImplementationChoice("", { escape: false, return: true }, 0), "implement");
+  assert.equal(getPlanImplementationChoice("", { escape: false, return: true }, 3), "clearContext");
+});
+
 test("prompt return key action submits on plain enter", () => {
   const { key } = parseTerminalInput("\r");
   assert.equal(getPromptReturnKeyAction(key), "submit");

--- a/packages/cli/src/tests/session-list.test.ts
+++ b/packages/cli/src/tests/session-list.test.ts
@@ -1,6 +1,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { formatSessionTitle, filterSessions, formatSessionStatus } from "../ui";
+import React from "react";
+import { renderToString } from "ink";
+import { formatSessionTitle, filterSessions, formatSessionStatus, getSessionBadges } from "../ui/views/SessionList";
+import { SessionList } from "../ui/views/SessionList";
+import { claimPlanImplementation, isActiveSessionEvent } from "../ui/core/session-events";
 import type { SessionEntry } from "@vegamo/deepcode-core";
 
 test("formatSessionTitle replaces newlines with spaces", () => {
@@ -9,6 +13,69 @@ test("formatSessionTitle replaces newlines with spaces", () => {
 
 test("formatSessionTitle truncates after normalizing whitespace", () => {
   assert.equal(formatSessionTitle("one\n two   three", 10), "one two th…");
+});
+
+test("plan derivation badges remain separate from long truncated titles", () => {
+  const [source, implementation, fork] = buildSessions([
+    { id: "source", summary: "A very long plan title that must be independently truncated" },
+    {
+      id: "implementation",
+      summary: "A very long plan title that must be independently truncated",
+      derivedFrom: { kind: "plan-implementation", sessionId: "source", messageId: "plan-message" },
+    },
+    { id: "fork", forkedFrom: { sessionId: "source", messageId: "plan-message" } },
+  ]);
+
+  assert.equal(formatSessionTitle(source!.summary!, 20), "A very long plan tit…");
+  assert.deepEqual(getSessionBadges(source!, [source!, implementation!, fork!]), ["planned"]);
+  assert.deepEqual(getSessionBadges(implementation!, [source!, implementation!, fork!]), ["implementation"]);
+  assert.deepEqual(getSessionBadges(fork!, [source!, implementation!, fork!]), []);
+});
+
+test("session callbacks ignore events from inactive sessions", () => {
+  assert.equal(isActiveSessionEvent("implementation", "source"), false);
+  assert.equal(isActiveSessionEvent("implementation", "implementation"), true);
+  assert.equal(isActiveSessionEvent("implementation", undefined), false);
+  assert.equal(isActiveSessionEvent(null, "source"), false);
+  assert.equal(isActiveSessionEvent(null, undefined), false);
+});
+
+test("plan implementation can only be claimed once while preparation is in flight", () => {
+  const inFlight = { current: false };
+
+  assert.equal(claimPlanImplementation(inFlight), true);
+  assert.equal(claimPlanImplementation(inFlight), false);
+});
+
+test("long session titles keep lineage badges and status on the first line at 80 columns", () => {
+  const sessions = buildSessions([
+    { id: "source", summary: "A very long plan title ".repeat(8) },
+    {
+      id: "implementation",
+      summary: "A very long implementation title ".repeat(8),
+      derivedFrom: { kind: "plan-implementation", sessionId: "source", messageId: "plan-message" },
+    },
+  ]);
+  const output = renderToString(
+    React.createElement(SessionList, {
+      sessions,
+      onSelect: () => {},
+      onCancel: () => {},
+    }),
+    { columns: 80 }
+  );
+  const lines = output.split("\n");
+  const titleLine = lines.find((line) => line.includes("[planned]"));
+  const implementationLine = lines.find((line) => line.includes("[implementation]"));
+
+  assert.match(titleLine ?? "", /… +\[planned\] \(done\) │$/);
+  assert.match(implementationLine ?? "", /… +\[implementation\] \(done\) │$/);
+  const plannedTimeLine = lines[lines.indexOf(titleLine ?? "") + 1] ?? "";
+  const implementationTimeLine = lines[lines.indexOf(implementationLine ?? "") + 1] ?? "";
+  assert.match(plannedTimeLine, /2026/);
+  assert.doesNotMatch(plannedTimeLine, /\[planned\]|\(done\)/);
+  assert.match(implementationTimeLine, /2026/);
+  assert.doesNotMatch(implementationTimeLine, /\[implementation\]|\(done\)/);
 });
 
 test("formatSessionStatus maps status values to display labels", () => {
@@ -101,7 +168,7 @@ test("filterSessions handles sessions with null fields", () => {
 
 function buildSessions(overrides: Array<Partial<SessionEntry>>): SessionEntry[] {
   return overrides.map((override, i) => ({
-    id: `session-${i}`,
+    id: override.id ?? `session-${i}`,
     summary: override.summary ?? null,
     assistantReply: override.assistantReply ?? null,
     assistantThinking: null,
@@ -115,5 +182,7 @@ function buildSessions(overrides: Array<Partial<SessionEntry>>): SessionEntry[] 
     createTime: new Date().toISOString(),
     updateTime: new Date().toISOString(),
     processes: null,
+    forkedFrom: override.forkedFrom,
+    derivedFrom: override.derivedFrom,
   }));
 }

--- a/packages/cli/src/ui/core/session-events.ts
+++ b/packages/cli/src/ui/core/session-events.ts
@@ -1,0 +1,11 @@
+export function isActiveSessionEvent(activeSessionId: string | null, eventSessionId?: string): boolean {
+  return activeSessionId !== null && eventSessionId === activeSessionId;
+}
+
+export function claimPlanImplementation(inFlight: { current: boolean }): boolean {
+  if (inFlight.current) {
+    return false;
+  }
+  inFlight.current = true;
+  return true;
+}

--- a/packages/cli/src/ui/views/App.tsx
+++ b/packages/cli/src/ui/views/App.tsx
@@ -20,7 +20,12 @@ import {
   formatAskUserQuestionAnswers,
 } from "../core/ask-user-question";
 import { PermissionPrompt, type PermissionPromptResult } from "./PermissionPrompt";
-import { PlanImplementationPrompt, extractProposedPlan, getImplementationPrompt } from "./PlanImplementationPrompt";
+import {
+  PlanImplementationPrompt,
+  extractProposedPlan,
+  getImplementationPrompt,
+  type PlanImplementationChoice,
+} from "./PlanImplementationPrompt";
 import { buildExitSummaryText, buildPluginRateLimitHintText, buildResumeHintText } from "../exit-summary";
 import { RawMode, useRawModeContext } from "../contexts";
 import { renderMessageToStdout } from "../components/MessageView/utils";
@@ -561,10 +566,44 @@ function App({ projectRoot, initialPrompt, resumeSessionId, forkSessionId, onRes
   );
 
   const handlePlanImplementationChoice = useCallback(
-    (choice: "implement" | "stay" | "default") => {
+    async (choice: PlanImplementationChoice) => {
       const proposedPlan = pendingPlanImplementation;
       setPendingPlanImplementation(null);
       if (choice === "stay") {
+        return;
+      }
+      if (choice === "clearContext" && proposedPlan) {
+        const sourceSessionId = sessionManager.getActiveSessionId();
+        if (!sourceSessionId) {
+          setErrorLine("No active session to derive from.");
+          return;
+        }
+        try {
+          const sessionId = sessionManager.startPlanImplementationSession(sourceSessionId, proposedPlan);
+          sessionManager.setActiveSessionId(sessionId);
+          await resetStaticView(loadVisibleMessages(sessionManager, sessionId), { clearScreen: true });
+          const session = sessionManager.getSession(sessionId);
+          setStatusLine(session ? buildStatusLine(session, resolveCurrentSettings(projectRoot)) : "");
+          setRunningProcesses(null);
+          setActiveStatus(session?.status ?? null);
+          setActiveAskPermissions(undefined);
+          setPlanMode(false);
+          setPendingPermissionReply(null);
+          setErrorLine(null);
+          const source = sessionManager.getSession(sourceSessionId);
+          if (source?.summary && !source.summary.includes("（规划）")) {
+            sessionManager.renameSession(sourceSessionId, `${source.summary}（规划）`);
+          }
+          refreshSessionsList();
+          await refreshSkills(sessionId);
+          handleSubmit({
+            text: getImplementationPrompt(proposedPlan),
+            imageUrls: [],
+            planMode: false,
+          });
+        } catch (error) {
+          setErrorLine(error instanceof Error ? error.message : String(error));
+        }
         return;
       }
       setPlanMode(false);
@@ -576,7 +615,15 @@ function App({ projectRoot, initialPrompt, resumeSessionId, forkSessionId, onRes
         });
       }
     },
-    [handleSubmit, pendingPlanImplementation]
+    [
+      handleSubmit,
+      pendingPlanImplementation,
+      sessionManager,
+      resetStaticView,
+      refreshSessionsList,
+      refreshSkills,
+      projectRoot,
+    ]
   );
 
   const handleExitShortcut = useCallback(() => {

--- a/packages/cli/src/ui/views/App.tsx
+++ b/packages/cli/src/ui/views/App.tsx
@@ -578,10 +578,16 @@ function App({ projectRoot, initialPrompt, resumeSessionId, forkSessionId, onRes
           setErrorLine("No active session to derive from.");
           return;
         }
+        let derivedSessionId: string | null = null;
+        let submissionStarted = false;
         try {
-          const sessionId = sessionManager.startPlanImplementationSession(sourceSessionId, proposedPlan);
+          const { sessionId, implementationPrompt } = await sessionManager.startPlanImplementationSession(
+            sourceSessionId,
+            proposedPlan
+          );
+          derivedSessionId = sessionId;
           sessionManager.setActiveSessionId(sessionId);
-          setPendingPlanImplementation(null);
+          processStdoutRef.current.clear();
           await resetStaticView(loadVisibleMessages(sessionManager, sessionId), { clearScreen: true });
           const session = sessionManager.getSession(sessionId);
           setStatusLine(session ? buildStatusLine(session, resolveCurrentSettings(projectRoot)) : "");
@@ -591,20 +597,35 @@ function App({ projectRoot, initialPrompt, resumeSessionId, forkSessionId, onRes
           setPlanMode(false);
           setPendingPermissionReply(null);
           setErrorLine(null);
-          const source = sessionManager.getSession(sourceSessionId);
-          if (source?.summary && !source.summary.includes(" (planned)")) {
-            sessionManager.renameSession(sourceSessionId, `${source.summary} (planned)`);
-          }
           refreshSessionsList();
           await refreshSkills(sessionId);
-          handleSubmit({
-            text: getImplementationPrompt(proposedPlan),
+          setPendingPlanImplementation(null);
+          submissionStarted = true;
+          await handlePrompt({
+            text: implementationPrompt,
             imageUrls: [],
             planMode: false,
           });
         } catch (error) {
+          if (submissionStarted) {
+            setErrorLine(error instanceof Error ? error.message : String(error));
+            return;
+          }
+          if (derivedSessionId) {
+            sessionManager.deleteSession(derivedSessionId);
+          }
+          sessionManager.setActiveSessionId(sourceSessionId);
+          processStdoutRef.current.clear();
+          await resetStaticView(loadVisibleMessages(sessionManager, sourceSessionId), { clearScreen: true });
+          const source = sessionManager.getSession(sourceSessionId);
+          setStatusLine(source ? buildStatusLine(source, resolveCurrentSettings(projectRoot)) : "");
+          setRunningProcesses(source?.processes ?? null);
+          setActiveStatus(source?.status ?? null);
+          setActiveAskPermissions(source?.askPermissions);
+          setPlanMode(true);
           setErrorLine(error instanceof Error ? error.message : String(error));
           setPendingPlanImplementation(proposedPlan);
+          refreshSessionsList();
         }
         return;
       }
@@ -620,6 +641,7 @@ function App({ projectRoot, initialPrompt, resumeSessionId, forkSessionId, onRes
     },
     [
       handleSubmit,
+      handlePrompt,
       pendingPlanImplementation,
       sessionManager,
       resetStaticView,

--- a/packages/cli/src/ui/views/App.tsx
+++ b/packages/cli/src/ui/views/App.tsx
@@ -10,6 +10,7 @@ import { SessionList } from "./SessionList";
 import { type UndoRestoreMode, UndoSelector } from "./UndoSelector";
 import { buildLoadingText } from "../core/loading-text";
 import { findExpandedThinkingId } from "../core/thinking-state";
+import { claimPlanImplementation, isActiveSessionEvent } from "../core/session-events";
 import { WelcomeScreen } from "./WelcomeScreen";
 import { AskUserQuestionPrompt } from "./AskUserQuestionPrompt";
 import { McpStatusList } from "./McpStatusList";
@@ -111,6 +112,7 @@ function App({ projectRoot, initialPrompt, resumeSessionId, forkSessionId, onRes
   const resumeSessionIdRef = useRef(false);
   const startupDoneRef = useRef(false);
   const processStdoutRef = useRef<Map<number, string>>(new Map());
+  const planImplementationInFlightRef = useRef(false);
   const rawModeRef = useRef<RawMode>(mode);
   const writeRef = useRef(write);
   const lastRenderedColumnsRef = useRef<number | null>(null);
@@ -155,6 +157,9 @@ function App({ projectRoot, initialPrompt, resumeSessionId, forkSessionId, onRes
       getResolvedSettings: () => resolveCurrentSettings(projectRoot),
       renderMarkdown: (text) => text,
       onAssistantMessage: (message: SessionMessage) => {
+        if (!isActiveSessionEvent(sessionManager.getActiveSessionId(), message.sessionId)) {
+          return;
+        }
         setMessages((prev) => [...prev, message]);
         if (rawModeRef.current === RawMode.Raw) {
           writeStdoutLine("\n");
@@ -162,12 +167,19 @@ function App({ projectRoot, initialPrompt, resumeSessionId, forkSessionId, onRes
         }
       },
       onSessionEntryUpdated: (entry) => {
+        setSessions(sessionManager.listSessions());
+        if (!isActiveSessionEvent(sessionManager.getActiveSessionId(), entry.id)) {
+          return;
+        }
         setStatusLine(buildStatusLine(entry, resolveCurrentSettings(projectRoot)));
         setRunningProcesses(entry.processes);
         setActiveStatus(entry.status);
         setActiveAskPermissions(entry.askPermissions);
       },
       onLlmStreamProgress: (progress) => {
+        if (!isActiveSessionEvent(sessionManager.getActiveSessionId(), progress.sessionId)) {
+          return;
+        }
         setRetryEvent(null);
         if (progress.phase === "end") {
           setStreamProgress(null);
@@ -176,13 +188,19 @@ function App({ projectRoot, initialPrompt, resumeSessionId, forkSessionId, onRes
         setStreamProgress(progress);
       },
       onLlmRetry: (event) => {
+        if (!isActiveSessionEvent(sessionManager.getActiveSessionId(), event.sessionId)) {
+          return;
+        }
         setRetryEvent(event);
       },
       onMcpStatusChanged: () => {
         // 当 MCP 状态变更时，如果当前正在查看 MCP 状态页面，则更新显示
         setMcpStatuses(sessionManager.getMcpStatus());
       },
-      onProcessStdout: (pid, chunk) => {
+      onProcessStdout: (pid, chunk, sessionId) => {
+        if (!isActiveSessionEvent(sessionManager.getActiveSessionId(), sessionId)) {
+          return;
+        }
         const buf = processStdoutRef.current;
         const current = buf.get(pid) ?? "";
         // Cap at 1 MB per process to avoid unbounded memory growth
@@ -342,6 +360,25 @@ function App({ projectRoot, initialPrompt, resumeSessionId, forkSessionId, onRes
     [exit, sessionManager]
   );
 
+  const activateSessionView = useCallback(
+    async (sessionId: string): Promise<void> => {
+      sessionManager.setActiveSessionId(sessionId);
+      processStdoutRef.current.clear();
+      await resetStaticView(loadVisibleMessages(sessionManager, sessionId), { clearScreen: true });
+      const session = sessionManager.getSession(sessionId);
+      setStatusLine(session ? buildStatusLine(session, resolveCurrentSettings(projectRoot)) : "");
+      setRunningProcesses(session?.processes ?? null);
+      setActiveStatus(session?.status ?? null);
+      setActiveAskPermissions(session?.askPermissions);
+      setPlanMode(session?.planMode === true);
+      setPendingPlanImplementation(null);
+      if (pendingPermissionReply && pendingPermissionReply.sessionId !== sessionId) {
+        setPendingPermissionReply(null);
+      }
+    },
+    [pendingPermissionReply, projectRoot, resetStaticView, sessionManager]
+  );
+
   const handlePrompt = useCallback(
     async (submission: PromptSubmission) => {
       if (submission.command === "exit") {
@@ -370,16 +407,7 @@ function App({ projectRoot, initialPrompt, resumeSessionId, forkSessionId, onRes
         }
         try {
           const sessionId = sessionManager.forkSession(sourceSessionId);
-          sessionManager.setActiveSessionId(sessionId);
-          await resetStaticView(loadVisibleMessages(sessionManager, sessionId), { clearScreen: true });
-          const session = sessionManager.getSession(sessionId);
-          setStatusLine(session ? buildStatusLine(session, resolveCurrentSettings(projectRoot)) : "");
-          setRunningProcesses(null);
-          setActiveStatus(session?.status ?? null);
-          setActiveAskPermissions(undefined);
-          setPlanMode(session?.planMode === true);
-          setPendingPlanImplementation(null);
-          setPendingPermissionReply(null);
+          await activateSessionView(sessionId);
           setErrorLine(null);
           refreshSessionsList();
           await refreshSkills(sessionId);
@@ -489,9 +517,8 @@ function App({ projectRoot, initialPrompt, resumeSessionId, forkSessionId, onRes
       refreshSessionsList,
       navigateToSubView,
       resetToWelcome,
-      resetStaticView,
       planMode,
-      projectRoot,
+      activateSessionView,
     ]
   );
 
@@ -578,54 +605,48 @@ function App({ projectRoot, initialPrompt, resumeSessionId, forkSessionId, onRes
           setErrorLine("No active session to derive from.");
           return;
         }
+        if (!claimPlanImplementation(planImplementationInFlightRef)) {
+          return;
+        }
+        setPendingPlanImplementation(null);
+        setBusy(true);
+        setErrorLine(null);
         let derivedSessionId: string | null = null;
-        let submissionStarted = false;
+        let implementationPrompt = "";
         try {
-          const { sessionId, implementationPrompt } = await sessionManager.startPlanImplementationSession(
-            sourceSessionId,
-            proposedPlan
-          );
-          derivedSessionId = sessionId;
-          sessionManager.setActiveSessionId(sessionId);
-          processStdoutRef.current.clear();
-          await resetStaticView(loadVisibleMessages(sessionManager, sessionId), { clearScreen: true });
-          const session = sessionManager.getSession(sessionId);
-          setStatusLine(session ? buildStatusLine(session, resolveCurrentSettings(projectRoot)) : "");
-          setRunningProcesses(null);
-          setActiveStatus(session?.status ?? null);
-          setActiveAskPermissions(undefined);
-          setPlanMode(false);
-          setPendingPermissionReply(null);
-          setErrorLine(null);
+          const result = await sessionManager.startPlanImplementationSession(sourceSessionId, proposedPlan);
+          derivedSessionId = result.sessionId;
+          implementationPrompt = result.implementationPrompt;
+          await activateSessionView(result.sessionId);
           refreshSessionsList();
-          await refreshSkills(sessionId);
-          setPendingPlanImplementation(null);
-          submissionStarted = true;
+        } catch (error) {
+          if (derivedSessionId) {
+            sessionManager.deleteSession(derivedSessionId);
+          }
+          try {
+            await activateSessionView(sourceSessionId);
+          } catch {
+            sessionManager.setActiveSessionId(sourceSessionId);
+          }
+          setErrorLine(error instanceof Error ? error.message : String(error));
+          setPendingPlanImplementation(proposedPlan);
+          refreshSessionsList();
+          setBusy(false);
+          planImplementationInFlightRef.current = false;
+          return;
+        }
+
+        try {
           await handlePrompt({
             text: implementationPrompt,
             imageUrls: [],
             planMode: false,
           });
         } catch (error) {
-          if (submissionStarted) {
-            setErrorLine(error instanceof Error ? error.message : String(error));
-            return;
-          }
-          if (derivedSessionId) {
-            sessionManager.deleteSession(derivedSessionId);
-          }
-          sessionManager.setActiveSessionId(sourceSessionId);
-          processStdoutRef.current.clear();
-          await resetStaticView(loadVisibleMessages(sessionManager, sourceSessionId), { clearScreen: true });
-          const source = sessionManager.getSession(sourceSessionId);
-          setStatusLine(source ? buildStatusLine(source, resolveCurrentSettings(projectRoot)) : "");
-          setRunningProcesses(source?.processes ?? null);
-          setActiveStatus(source?.status ?? null);
-          setActiveAskPermissions(source?.askPermissions);
-          setPlanMode(true);
           setErrorLine(error instanceof Error ? error.message : String(error));
-          setPendingPlanImplementation(proposedPlan);
-          refreshSessionsList();
+          setBusy(false);
+        } finally {
+          planImplementationInFlightRef.current = false;
         }
         return;
       }
@@ -639,16 +660,7 @@ function App({ projectRoot, initialPrompt, resumeSessionId, forkSessionId, onRes
         });
       }
     },
-    [
-      handleSubmit,
-      handlePrompt,
-      pendingPlanImplementation,
-      sessionManager,
-      resetStaticView,
-      refreshSessionsList,
-      refreshSkills,
-      projectRoot,
-    ]
+    [handleSubmit, handlePrompt, pendingPlanImplementation, sessionManager, activateSessionView, refreshSessionsList]
   );
 
   const handleExitShortcut = useCallback(() => {
@@ -664,22 +676,10 @@ function App({ projectRoot, initialPrompt, resumeSessionId, forkSessionId, onRes
 
   const handleSelectSession = useCallback(
     async (sessionId: string) => {
-      sessionManager.setActiveSessionId(sessionId);
-      // Clear first so <Static> resets its index to 0.
-      await resetStaticView(loadVisibleMessages(sessionManager, sessionId), { clearScreen: true });
-      const session = sessionManager.getSession(sessionId);
-      setStatusLine(session ? buildStatusLine(session, resolveCurrentSettings(projectRoot)) : "");
-      setRunningProcesses(session?.processes ?? null);
-      setActiveStatus(session?.status ?? null);
-      setActiveAskPermissions(session?.askPermissions);
-      setPlanMode(session?.planMode === true);
-      setPendingPlanImplementation(null);
-      if (pendingPermissionReply && pendingPermissionReply.sessionId !== sessionId) {
-        setPendingPermissionReply(null);
-      }
+      await activateSessionView(sessionId);
       await refreshSkills(sessionId);
     },
-    [sessionManager, resetStaticView, pendingPermissionReply, projectRoot, refreshSkills]
+    [activateSessionView, refreshSkills]
   );
 
   /**

--- a/packages/cli/src/ui/views/App.tsx
+++ b/packages/cli/src/ui/views/App.tsx
@@ -568,8 +568,8 @@ function App({ projectRoot, initialPrompt, resumeSessionId, forkSessionId, onRes
   const handlePlanImplementationChoice = useCallback(
     async (choice: PlanImplementationChoice) => {
       const proposedPlan = pendingPlanImplementation;
-      setPendingPlanImplementation(null);
       if (choice === "stay") {
+        setPendingPlanImplementation(null);
         return;
       }
       if (choice === "clearContext" && proposedPlan) {
@@ -581,6 +581,7 @@ function App({ projectRoot, initialPrompt, resumeSessionId, forkSessionId, onRes
         try {
           const sessionId = sessionManager.startPlanImplementationSession(sourceSessionId, proposedPlan);
           sessionManager.setActiveSessionId(sessionId);
+          setPendingPlanImplementation(null);
           await resetStaticView(loadVisibleMessages(sessionManager, sessionId), { clearScreen: true });
           const session = sessionManager.getSession(sessionId);
           setStatusLine(session ? buildStatusLine(session, resolveCurrentSettings(projectRoot)) : "");
@@ -591,8 +592,8 @@ function App({ projectRoot, initialPrompt, resumeSessionId, forkSessionId, onRes
           setPendingPermissionReply(null);
           setErrorLine(null);
           const source = sessionManager.getSession(sourceSessionId);
-          if (source?.summary && !source.summary.includes("（规划）")) {
-            sessionManager.renameSession(sourceSessionId, `${source.summary}（规划）`);
+          if (source?.summary && !source.summary.includes(" (planned)")) {
+            sessionManager.renameSession(sourceSessionId, `${source.summary} (planned)`);
           }
           refreshSessionsList();
           await refreshSkills(sessionId);
@@ -603,9 +604,11 @@ function App({ projectRoot, initialPrompt, resumeSessionId, forkSessionId, onRes
           });
         } catch (error) {
           setErrorLine(error instanceof Error ? error.message : String(error));
+          setPendingPlanImplementation(proposedPlan);
         }
         return;
       }
+      setPendingPlanImplementation(null);
       setPlanMode(false);
       if (choice === "implement" && proposedPlan) {
         handleSubmit({

--- a/packages/cli/src/ui/views/PlanImplementationPrompt.tsx
+++ b/packages/cli/src/ui/views/PlanImplementationPrompt.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink";
 import { useTerminalInput } from "../hooks";
 import type { InputKey } from "../hooks";
 
-type PlanImplementationChoice = "implement" | "stay" | "default";
+export type PlanImplementationChoice = "implement" | "stay" | "default" | "clearContext";
 
 type Props = {
   onSelect: (choice: PlanImplementationChoice) => void;
@@ -13,6 +13,7 @@ const CHOICES: Array<{ value: PlanImplementationChoice; label: string }> = [
   { value: "implement", label: "implement this plan" },
   { value: "stay", label: "stay in Plan mode" },
   { value: "default", label: "switch to Default mode" },
+  { value: "clearContext", label: "clear context and implement this plan" },
 ];
 
 /** Return only a complete proposed plan, so historical or partial tags cannot trigger the chooser. */
@@ -37,7 +38,7 @@ export function getPlanImplementationChoice(
   if (key.escape) {
     return "stay";
   }
-  if (input && /^[1-3]$/.test(input)) {
+  if (input && /^[1-4]$/.test(input)) {
     return CHOICES[Number(input) - 1]!.value;
   }
   return key.return ? CHOICES[cursor]!.value : null;
@@ -81,7 +82,7 @@ export function PlanImplementationPrompt({ onSelect }: Props): React.ReactElemen
         ))}
       </Box>
       <Box marginTop={1}>
-        <Text dimColor>1-3 select · ↑/↓ move · Enter select</Text>
+        <Text dimColor>1-4 select · ↑/↓ move · Enter select</Text>
       </Box>
     </Box>
   );

--- a/packages/cli/src/ui/views/PlanImplementationPrompt.tsx
+++ b/packages/cli/src/ui/views/PlanImplementationPrompt.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Box, Text } from "ink";
+import { extractProposedPlan } from "@vegamo/deepcode-core";
 import { useTerminalInput } from "../hooks";
 import type { InputKey } from "../hooks";
 
@@ -16,14 +17,7 @@ const CHOICES: Array<{ value: PlanImplementationChoice; label: string }> = [
   { value: "clearContext", label: "clear context and implement this plan" },
 ];
 
-/** Return only a complete proposed plan, so historical or partial tags cannot trigger the chooser. */
-export function extractProposedPlan(reply: string | null): string | null {
-  if (!reply) {
-    return null;
-  }
-  const match = reply.match(/<proposed_plan>\s*([\s\S]*?\S[\s\S]*?)\s*<\/proposed_plan>/);
-  return match?.[1] ?? null;
-}
+export { extractProposedPlan };
 
 export function getImplementationPrompt(plan: string): string {
   const fullWidthPunctuationCount = (plan.match(/[，、；。]/g) ?? []).length;

--- a/packages/cli/src/ui/views/SessionList.tsx
+++ b/packages/cli/src/ui/views/SessionList.tsx
@@ -312,13 +312,14 @@ export function SessionList({ sessions, onSelect, onCancel, onDelete, onRename }
               const isSelected = actualIndex === safeIndex;
               const isConfirming = confirmDeleteSessionId === session.id;
               const isRenaming = renameSessionId === session.id;
+              const badges = getSessionBadges(session, sessions);
               return (
                 <Box key={session.id} height={2} marginBottom={1}>
                   <Box>
                     <Text color="#229ac3">{isSelected ? "> " : "  "}</Text>
                   </Box>
                   <Box flexDirection="column" flexGrow={1}>
-                    <Box width={"100%"}>
+                    <Box width={"100%"} flexWrap="nowrap">
                       {isRenaming ? (
                         <Text color="yellow">
                           Rename: {renameValue.slice(0, renameCursor)}
@@ -326,15 +327,30 @@ export function SessionList({ sessions, onSelect, onCancel, onDelete, onRename }
                           {renameValue.slice(renameCursor)}
                         </Text>
                       ) : (
-                        <Text {...(isSelected ? { bold: true } : {})} color={isSelected ? "#229ac3" : undefined}>
-                          {formatSessionTitle(session.summary || "Untitled")}
-                        </Text>
+                        <Box flexGrow={1} flexShrink={1} overflow="hidden">
+                          <Text
+                            wrap="truncate-end"
+                            {...(isSelected ? { bold: true } : {})}
+                            color={isSelected ? "#229ac3" : undefined}
+                          >
+                            {formatSessionTitle(session.summary || "Untitled")}
+                          </Text>
+                        </Box>
                       )}
-                      {isConfirming ? (
-                        <Text color="yellow"> [Delete? Enter=yes, Esc=no]</Text>
-                      ) : isRenaming ? null : (
-                        <Text dimColor> ({formatSessionStatus(session.status)})</Text>
-                      )}
+                      {!isRenaming ? (
+                        <Box flexShrink={0}>
+                          {badges.map((badge) => (
+                            <Text key={badge} color={badge === "implementation" ? "cyan" : "yellow"}>
+                              {` [${badge}]`}
+                            </Text>
+                          ))}
+                          {isConfirming ? (
+                            <Text color="yellow"> [Delete? Enter=yes, Esc=no]</Text>
+                          ) : (
+                            <Text dimColor> ({formatSessionStatus(session.status)})</Text>
+                          )}
+                        </Box>
+                      ) : null}
                     </Box>
                     <Box width="100%">
                       <Text dimColor>{formatTimestamp(session.updateTime)} </Text>
@@ -411,6 +427,22 @@ function formatTimestamp(value: string): string {
 
 export function formatSessionTitle(value: string, max = 70): string {
   return truncate(value.replace(/\r?\n/g, " ").replace(/\s+/g, " ").trim(), max);
+}
+
+export function getSessionBadges(session: SessionEntry, sessions: SessionEntry[]): Array<"planned" | "implementation"> {
+  const badges: Array<"planned" | "implementation"> = [];
+  if (
+    sessions.some(
+      (candidate) =>
+        candidate.derivedFrom?.kind === "plan-implementation" && candidate.derivedFrom.sessionId === session.id
+    )
+  ) {
+    badges.push("planned");
+  }
+  if (session.derivedFrom?.kind === "plan-implementation") {
+    badges.push("implementation");
+  }
+  return badges;
 }
 
 export function formatSessionStatus(status: SessionStatus): string {

--- a/packages/core/src/common/file-history.ts
+++ b/packages/core/src/common/file-history.ts
@@ -87,6 +87,19 @@ export class GitFileHistory {
     }
   }
 
+  deleteSession(sessionId: string): void {
+    const branchRef = this.getSessionBranchRef(sessionId);
+    if (!branchRef || !fs.existsSync(this.gitDir)) {
+      return;
+    }
+
+    try {
+      this.runGit(["update-ref", "-d", branchRef]);
+    } catch {
+      // File history is best effort and must not block session cleanup.
+    }
+  }
+
   recordCheckpoint(sessionId: string, filePaths: string[], message: string): string | undefined {
     const branchRef = this.getSessionBranchRef(sessionId);
     if (!branchRef) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,7 +41,13 @@ export type {
 } from "./settings";
 
 // Session
-export { SessionManager, getProjectCode, getCompactPromptTokenThreshold } from "./session";
+export {
+  SessionManager,
+  buildPlanImplementationHandoff,
+  extractProposedPlan,
+  getProjectCode,
+  getCompactPromptTokenThreshold,
+} from "./session";
 export type {
   SessionMessage,
   SessionEntry,
@@ -58,6 +64,7 @@ export type {
   LlmStreamProgress,
   LlmRetryEvent,
   SessionManagerOptions,
+  PlanImplementationSessionResult,
 } from "./session";
 
 // Prompt utilities

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -108,7 +108,19 @@ const PLAN_MODE_FORCE_ASK_SCOPES = [
   "mutate-git-log",
 ] as const satisfies readonly PermissionScope[];
 
-function buildPlanImplementationMessage(planText: string): string {
+export function extractProposedPlan(content: string | null): string | null {
+  if (!content) {
+    return null;
+  }
+
+  let latestPlan: string | null = null;
+  for (const match of content.matchAll(/<proposed_plan>\s*([\s\S]*?\S[\s\S]*?)\s*<\/proposed_plan>/g)) {
+    latestPlan = match[1] ?? null;
+  }
+  return latestPlan;
+}
+
+export function buildPlanImplementationHandoff(planText: string): string {
   const fullWidthPunctuationCount = (planText.match(/[，、；。]/g) ?? []).length;
   const directive =
     fullWidthPunctuationCount > 5
@@ -175,6 +187,10 @@ function replaceStringValues(value: unknown, search: string, replacement: string
 
 function isUsageRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
 }
 
 function summarizeCompletionOptions(options?: Record<string, unknown>): Record<string, unknown> | undefined {
@@ -300,6 +316,16 @@ export type SessionEntry = {
     sessionId: string;
     messageId: string;
   };
+  derivedFrom?: {
+    kind: "plan-implementation";
+    sessionId: string;
+    messageId: string;
+  };
+};
+
+export type PlanImplementationSessionResult = {
+  sessionId: string;
+  implementationPrompt: string;
 };
 
 export type SessionsIndex = {
@@ -317,7 +343,6 @@ export type MessageMeta = {
   asThinking?: boolean;
   isAnswers?: boolean;
   isSummary?: boolean;
-  isPlan?: boolean;
   isModelChange?: boolean;
   skill?: SkillInfo;
   skillCatalog?: Array<{ name: string; description: string }>;
@@ -395,7 +420,7 @@ export type SessionManagerOptions = {
   onLlmStreamProgress?: (progress: LlmStreamProgress) => void;
   onLlmRetry?: (event: LlmRetryEvent) => void;
   onMcpStatusChanged?: () => void;
-  onProcessStdout?: (pid: number, chunk: string) => void;
+  onProcessStdout?: (pid: number, chunk: string, sessionId: string) => void;
   loadSharp?: SharpLoader;
   nonInteractive?: boolean;
 };
@@ -442,7 +467,7 @@ export class SessionManager {
   private readonly onLlmStreamProgress?: (progress: LlmStreamProgress) => void;
   private readonly onLlmRetry?: (event: LlmRetryEvent) => void;
   private readonly onMcpStatusChanged?: () => void;
-  private readonly onProcessStdout?: (pid: number, chunk: string) => void;
+  private readonly onProcessStdout?: (pid: number, chunk: string, sessionId: string) => void;
   private readonly nonInteractive: boolean;
   private activeSessionId: string | null = null;
   private activePromptController: AbortController | null = null;
@@ -1475,7 +1500,6 @@ ${agentInstructions}
     userPrompt = this.preparePromptImages(sessionId, userPrompt);
     this.ensureFileHistorySession(sessionId);
     const now = new Date().toISOString();
-    const index = this.loadSessionsIndex();
     const entry: SessionEntry = {
       id: sessionId,
       summary: originalSummary,
@@ -1493,46 +1517,10 @@ ${agentInstructions}
       processes: null,
       planMode: Boolean(userPrompt.planMode),
     };
-    index.entries.push(entry);
-    const sortedEntries = index.entries.slice().sort((a, b) => {
-      const aTime = Date.parse(a.updateTime);
-      const bTime = Date.parse(b.updateTime);
-      if (Number.isNaN(aTime) || Number.isNaN(bTime)) {
-        return b.updateTime.localeCompare(a.updateTime);
-      }
-      return bTime - aTime;
-    });
-    const keptEntries = sortedEntries.slice(0, MAX_SESSION_ENTRIES);
-    const keptIds = new Set(keptEntries.map((item) => item.id));
-    const droppedEntries = sortedEntries.filter((item) => !keptIds.has(item.id));
-    index.entries = keptEntries;
-    this.saveSessionsIndex(index);
-    for (const dropped of droppedEntries) {
-      this.cleanupSessionResources(dropped.id, {
-        removeMessages: true,
-        processIds: this.getProcessIds(dropped.processes ?? null),
-      });
-    }
+    this.registerSessionEntry(entry);
 
-    const promptToolOptions = this.getPromptToolOptions();
-    const systemPrompt = getSystemPrompt(this.projectRoot, promptToolOptions);
-    const systemMessage = this.buildSystemMessage(sessionId, systemPrompt);
-    this.appendSessionMessage(sessionId, systemMessage);
-
-    const runtimeContextMessage = this.buildSystemMessage(
-      sessionId,
-      getRuntimeContext(
-        this.projectRoot,
-        promptToolOptions.model,
-        this.getResolvedSettings().permissions?.addWorkingDirs
-      )
-    );
-    this.appendSessionMessage(sessionId, runtimeContextMessage);
-
-    const agentInstructions = this.loadAgentInstructions();
-    if (agentInstructions) {
-      const instructionsMessage = this.buildSystemMessage(sessionId, agentInstructions);
-      this.appendSessionMessage(sessionId, instructionsMessage);
+    for (const message of this.buildTrustedSessionPrefix(sessionId)) {
+      this.appendSessionMessage(sessionId, message);
     }
 
     this.appendPlanModeTransitionMessages(sessionId, false, Boolean(userPrompt.planMode));
@@ -1541,15 +1529,17 @@ ${agentInstructions}
     const userMessage = this.buildUserMessage(sessionId, userPrompt);
     this.appendSessionMessage(sessionId, userMessage);
 
+    this.activeSessionId = sessionId;
+
     let matchedSkills: SkillInfo[] = [];
     if (userPrompt.text) {
-      const skills = await this.listSkills();
-      const skillNames = await this.identifyMatchingSkillNames(skills, userPrompt.text, { signal });
+      const skills = await this.listSkills(sessionId);
+      const skillNames = await this.identifyMatchingSkillNames(skills, userPrompt.text, { signal, sessionId });
       this.throwIfAborted(signal);
       const skillSet = new Set(skillNames);
       matchedSkills = skills.filter((skill) => skillSet.has(skill.name));
     }
-    userPrompt.skills = await this.normalizeSkills(userPrompt.skills);
+    userPrompt.skills = await this.normalizeSkills(userPrompt.skills, sessionId);
     this.throwIfAborted(signal);
 
     this.appendSkillMessages(sessionId, userPrompt.skills);
@@ -1561,7 +1551,6 @@ ${agentInstructions}
       )
     );
 
-    this.activeSessionId = sessionId;
     await this.activateSession(sessionId, controller);
     return sessionId;
   }
@@ -2285,6 +2274,16 @@ ${agentInstructions}
     }
   }
 
+  private removeSessionEntryBestEffort(sessionId: string): void {
+    try {
+      const index = this.loadSessionsIndex();
+      index.entries = index.entries.filter((entry) => entry.id !== sessionId);
+      this.saveSessionsIndex(index);
+    } catch {
+      // Preserve the original creation error; cleanup is best effort.
+    }
+  }
+
   forkSession(sourceSessionId: string): string {
     const source = this.getSession(sourceSessionId);
     if (!source) {
@@ -2336,11 +2335,15 @@ ${agentInstructions}
   /**
    * Derive a clean implementation session from a completed Plan Mode session.
    * Unlike forkSession (which copies the full conversation history), this builds a
-   * fresh message list carrying only the system prompt, runtime context, AGENTS.md
-   * instructions, and the approved plan — so implementation starts from a clean
-   * context while file history stays traceable to the source session's checkpoint.
+   * fresh trusted prefix carrying the current system prompt, runtime context,
+   * AGENTS.md instructions, and a compact current skill catalog. The caller submits
+   * the returned user-role handoff so implementation starts from a clean context
+   * while file history stays traceable to the source session's checkpoint.
    */
-  startPlanImplementationSession(sourceSessionId: string, planText: string): string {
+  async startPlanImplementationSession(
+    sourceSessionId: string,
+    expectedPlan: string
+  ): Promise<PlanImplementationSessionResult> {
     const source = this.getSession(sourceSessionId);
     if (!source) {
       throw new Error(`No saved session found with ID "${sourceSessionId}".`);
@@ -2348,17 +2351,59 @@ ${agentInstructions}
     if (source.planMode !== true) {
       throw new Error(`Session "${sourceSessionId}" is not in Plan Mode.`);
     }
-
-    const trimmedPlanText = planText.trim();
-    if (!trimmedPlanText) {
+    if (source.status !== "completed") {
+      throw new Error(`Session "${sourceSessionId}" is not completed.`);
+    }
+    if (!expectedPlan.trim()) {
       throw new Error("The approved plan text must not be empty.");
     }
 
     const sourceMessages = this.listSessionMessages(sourceSessionId);
-    const sourceMessage = sourceMessages.at(-1);
-    if (!sourceMessage || typeof sourceMessage.id !== "string" || !sourceMessage.id) {
-      throw new Error(`Session "${sourceSessionId}" has no messages to derive from.`);
+    let sourceMessage: SessionMessage | undefined;
+    let planText: string | null = null;
+    for (let index = sourceMessages.length - 1; index >= 0; index -= 1) {
+      const message = sourceMessages[index];
+      if (message?.role !== "assistant") {
+        continue;
+      }
+      const proposedPlan = extractProposedPlan(message.content);
+      if (proposedPlan !== null) {
+        sourceMessage = message;
+        planText = proposedPlan;
+        break;
+      }
     }
+    if (!sourceMessage || planText === null) {
+      throw new Error(`Session "${sourceSessionId}" has no complete proposed plan to implement.`);
+    }
+    if (!isNonEmptyString(sourceMessage.id)) {
+      throw new Error(`Session "${sourceSessionId}" has a proposed plan without a valid message ID.`);
+    }
+    if (expectedPlan !== planText) {
+      throw new Error("The approved plan no longer matches the latest proposed plan in the source session.");
+    }
+
+    const advertisedSkillNames = new Set<string>();
+    const advertisedSkillPaths = new Set<string>();
+    for (const message of sourceMessages) {
+      if (typeof message.meta?.skill?.name === "string" && message.meta.skill.name) {
+        advertisedSkillNames.add(message.meta.skill.name);
+      }
+      if (typeof message.meta?.skill?.path === "string" && message.meta.skill.path) {
+        advertisedSkillPaths.add(message.meta.skill.path);
+      }
+      if (Array.isArray(message.meta?.skillCatalog)) {
+        for (const skill of message.meta.skillCatalog) {
+          if (typeof skill?.name === "string" && skill.name) {
+            advertisedSkillNames.add(skill.name);
+          }
+        }
+      }
+    }
+    const currentSkills = await this.listSkills();
+    const skillCatalog = currentSkills
+      .filter((skill) => advertisedSkillNames.has(skill.name) || advertisedSkillPaths.has(skill.path))
+      .map((skill) => ({ name: skill.name, description: skill.description }));
 
     const sessionId = crypto.randomUUID();
     const now = new Date().toISOString();
@@ -2378,42 +2423,34 @@ ${agentInstructions}
       updateTime: now,
       processes: null,
       planMode: false,
-      forkedFrom: {
+      derivedFrom: {
+        kind: "plan-implementation",
         sessionId: sourceSessionId,
         messageId: sourceMessage.id,
       },
     };
 
-    const promptToolOptions = this.getPromptToolOptions();
-    const messages: SessionMessage[] = [
-      this.buildSystemMessage(sessionId, getSystemPrompt(this.projectRoot, promptToolOptions)),
-      this.buildSystemMessage(
-        sessionId,
-        getRuntimeContext(
-          this.projectRoot,
-          promptToolOptions.model,
-          this.getResolvedSettings().permissions?.addWorkingDirs
-        )
-      ),
-    ];
-
-    const agentInstructions = this.loadAgentInstructions();
-    if (agentInstructions) {
-      messages.push(this.buildSystemMessage(sessionId, agentInstructions));
+    const messages = this.buildTrustedSessionPrefix(sessionId);
+    if (skillCatalog.length > 0) {
+      messages.push(
+        this.buildSystemMessage(sessionId, buildSkillCatalogPrompt(skillCatalog), null, false, { skillCatalog })
+      );
     }
 
-    messages.push(
-      this.buildSystemMessage(sessionId, buildPlanImplementationMessage(trimmedPlanText), null, false, {
-        isPlan: true,
-      })
-    );
+    try {
+      this.saveSessionMessages(sessionId, messages);
+      this.getFileHistory().forkSession(sourceSessionId, sessionId);
+      this.registerSessionEntry(entry);
+    } catch (error) {
+      this.removeSessionEntryBestEffort(sessionId);
+      this.cleanupSessionResources(sessionId, { removeMessages: true });
+      throw error;
+    }
 
-    this.saveSessionMessages(sessionId, messages);
-    this.getFileHistory().forkSession(sourceSessionId, sessionId);
-
-    this.registerSessionEntry(entry);
-
-    return sessionId;
+    return {
+      sessionId,
+      implementationPrompt: buildPlanImplementationHandoff(planText),
+    };
   }
 
   /**
@@ -2734,6 +2771,7 @@ ${agentInstructions}
       controller.abort();
     }
     this.sessionControllers.delete(sessionId);
+    this.getFileHistory().deleteSession(sessionId);
     if (options.removeMessages) {
       this.removeSessionMessages([sessionId]);
       try {
@@ -2995,6 +3033,26 @@ ${agentInstructions}
     };
   }
 
+  private buildTrustedSessionPrefix(sessionId: string): SessionMessage[] {
+    const promptToolOptions = this.getPromptToolOptions();
+    const messages = [
+      this.buildSystemMessage(sessionId, getSystemPrompt(this.projectRoot, promptToolOptions)),
+      this.buildSystemMessage(
+        sessionId,
+        getRuntimeContext(
+          this.projectRoot,
+          promptToolOptions.model,
+          this.getResolvedSettings().permissions?.addWorkingDirs
+        )
+      ),
+    ];
+    const agentInstructions = this.loadAgentInstructions();
+    if (agentInstructions) {
+      messages.push(this.buildSystemMessage(sessionId, agentInstructions));
+    }
+    return messages;
+  }
+
   private buildFollowUpMessage(sessionId: string, message: ToolExecutionFollowUpMessage): SessionMessage {
     const now = new Date().toISOString();
     return {
@@ -3167,7 +3225,7 @@ ${agentInstructions}
     const hooks: ToolExecutionHooks = {
       onProcessStart: (pid, command) => this.addSessionProcess(sessionId, pid, command),
       onProcessExit: (pid) => this.removeSessionProcess(sessionId, pid),
-      onProcessStdout: (pid, chunk) => this.onProcessStdout?.(Number(pid), chunk),
+      onProcessStdout: (pid, chunk) => this.onProcessStdout?.(Number(pid), chunk, sessionId),
       onProcessTimeoutControl: (pid, control) => this.setSessionProcessTimeoutControl(sessionId, pid, control),
       onBackgroundProcessComplete: (completion) => this.addBackgroundProcessCompletionMessage(sessionId, completion),
       onBeforeFileMutation: (filePath) => this.prepareFileMutationCheckpoint(sessionId, filePath),
@@ -3654,6 +3712,7 @@ ${agentInstructions}
       planMode: value.planMode === true,
       pluginRateLimitedTool: this.normalizePluginRateLimitedTool(value.pluginRateLimitedTool),
       forkedFrom: this.normalizeForkedFrom(value.forkedFrom),
+      derivedFrom: this.normalizeDerivedFrom(value.derivedFrom),
     };
   }
 
@@ -3666,17 +3725,30 @@ ${agentInstructions}
       return undefined;
     }
     const forkedFrom = value as Record<string, unknown>;
-    if (
-      typeof forkedFrom.sessionId !== "string" ||
-      !forkedFrom.sessionId ||
-      typeof forkedFrom.messageId !== "string" ||
-      !forkedFrom.messageId
-    ) {
+    if (!isNonEmptyString(forkedFrom.sessionId) || !isNonEmptyString(forkedFrom.messageId)) {
       return undefined;
     }
     return {
       sessionId: forkedFrom.sessionId,
       messageId: forkedFrom.messageId,
+    };
+  }
+
+  private normalizeDerivedFrom(value: unknown): SessionEntry["derivedFrom"] {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return undefined;
+    }
+    const derivedFrom = value as Record<string, unknown>;
+    if (derivedFrom.kind !== "plan-implementation") {
+      return undefined;
+    }
+    const lineage = this.normalizeForkedFrom(value);
+    if (!lineage) {
+      return undefined;
+    }
+    return {
+      kind: "plan-implementation",
+      ...lineage,
     };
   }
 

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -108,6 +108,15 @@ const PLAN_MODE_FORCE_ASK_SCOPES = [
   "mutate-git-log",
 ] as const satisfies readonly PermissionScope[];
 
+function buildPlanImplementationMessage(planText: string): string {
+  const fullWidthPunctuationCount = (planText.match(/[，、；。]/g) ?? []).length;
+  const directive =
+    fullWidthPunctuationCount > 5
+      ? "先前的一位智能体产出了以下方案以完成用户任务。请在全新上下文中实现该方案，把方案视为用户意图的来源，按需重新读取文件，并持续推进到实现与验证。"
+      : "A previous agent produced the plan below to accomplish the user's task. Implement the plan in a fresh context. Treat the plan as the source of user intent, re-read files as needed, and carry the work through implementation and verification.";
+  return `${directive}\n\n<proposed_plan>\n${planText}\n</proposed_plan>`;
+}
+
 type ChatCompletionDebugOptions = {
   enabled?: boolean;
   location: string;
@@ -308,6 +317,7 @@ export type MessageMeta = {
   asThinking?: boolean;
   isAnswers?: boolean;
   isSummary?: boolean;
+  isPlan?: boolean;
   isModelChange?: boolean;
   skill?: SkillInfo;
   skillCatalog?: Array<{ name: string; description: string }>;
@@ -2251,6 +2261,30 @@ ${agentInstructions}
     return index.entries.find((entry) => entry.id === sessionId) ?? null;
   }
 
+  private registerSessionEntry(entry: SessionEntry): void {
+    const index = this.loadSessionsIndex();
+    index.entries.push(entry);
+    const sortedEntries = index.entries.slice().sort((a, b) => {
+      const aTime = Date.parse(a.updateTime);
+      const bTime = Date.parse(b.updateTime);
+      if (Number.isNaN(aTime) || Number.isNaN(bTime)) {
+        return b.updateTime.localeCompare(a.updateTime);
+      }
+      return bTime - aTime;
+    });
+    const keptEntries = sortedEntries.slice(0, MAX_SESSION_ENTRIES);
+    const keptIds = new Set(keptEntries.map((item) => item.id));
+    const droppedEntries = sortedEntries.filter((item) => !keptIds.has(item.id));
+    index.entries = keptEntries;
+    this.saveSessionsIndex(index);
+    for (const dropped of droppedEntries) {
+      this.cleanupSessionResources(dropped.id, {
+        removeMessages: true,
+        processIds: this.getProcessIds(dropped.processes ?? null),
+      });
+    }
+  }
+
   forkSession(sourceSessionId: string): string {
     const source = this.getSession(sourceSessionId);
     if (!source) {
@@ -2294,27 +2328,7 @@ ${agentInstructions}
     this.saveSessionMessages(sessionId, forkedMessages);
     this.getFileHistory().forkSession(sourceSessionId, sessionId);
 
-    const index = this.loadSessionsIndex();
-    index.entries.push(entry);
-    const sortedEntries = index.entries.slice().sort((a, b) => {
-      const aTime = Date.parse(a.updateTime);
-      const bTime = Date.parse(b.updateTime);
-      if (Number.isNaN(aTime) || Number.isNaN(bTime)) {
-        return b.updateTime.localeCompare(a.updateTime);
-      }
-      return bTime - aTime;
-    });
-    const keptEntries = sortedEntries.slice(0, MAX_SESSION_ENTRIES);
-    const keptIds = new Set(keptEntries.map((item) => item.id));
-    const droppedEntries = sortedEntries.filter((item) => !keptIds.has(item.id));
-    index.entries = keptEntries;
-    this.saveSessionsIndex(index);
-    for (const dropped of droppedEntries) {
-      this.cleanupSessionResources(dropped.id, {
-        removeMessages: true,
-        processIds: this.getProcessIds(dropped.processes ?? null),
-      });
-    }
+    this.registerSessionEntry(entry);
 
     return sessionId;
   }
@@ -2330,6 +2344,14 @@ ${agentInstructions}
     const source = this.getSession(sourceSessionId);
     if (!source) {
       throw new Error(`No saved session found with ID "${sourceSessionId}".`);
+    }
+    if (source.planMode !== true) {
+      throw new Error(`Session "${sourceSessionId}" is not in Plan Mode.`);
+    }
+
+    const trimmedPlanText = planText.trim();
+    if (!trimmedPlanText) {
+      throw new Error("The approved plan text must not be empty.");
     }
 
     const sourceMessages = this.listSessionMessages(sourceSessionId);
@@ -2381,35 +2403,15 @@ ${agentInstructions}
     }
 
     messages.push(
-      this.buildSystemMessage(sessionId, `<proposed_plan>\n${planText}\n</proposed_plan>`, null, false, {
-        isSummary: true,
+      this.buildSystemMessage(sessionId, buildPlanImplementationMessage(trimmedPlanText), null, false, {
+        isPlan: true,
       })
     );
 
     this.saveSessionMessages(sessionId, messages);
     this.getFileHistory().forkSession(sourceSessionId, sessionId);
 
-    const index = this.loadSessionsIndex();
-    index.entries.push(entry);
-    const sortedEntries = index.entries.slice().sort((a, b) => {
-      const aTime = Date.parse(a.updateTime);
-      const bTime = Date.parse(b.updateTime);
-      if (Number.isNaN(aTime) || Number.isNaN(bTime)) {
-        return b.updateTime.localeCompare(a.updateTime);
-      }
-      return bTime - aTime;
-    });
-    const keptEntries = sortedEntries.slice(0, MAX_SESSION_ENTRIES);
-    const keptIds = new Set(keptEntries.map((item) => item.id));
-    const droppedEntries = sortedEntries.filter((item) => !keptIds.has(item.id));
-    index.entries = keptEntries;
-    this.saveSessionsIndex(index);
-    for (const dropped of droppedEntries) {
-      this.cleanupSessionResources(dropped.id, {
-        removeMessages: true,
-        processIds: this.getProcessIds(dropped.processes ?? null),
-      });
-    }
+    this.registerSessionEntry(entry);
 
     return sessionId;
   }

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -2320,6 +2320,101 @@ ${agentInstructions}
   }
 
   /**
+   * Derive a clean implementation session from a completed Plan Mode session.
+   * Unlike forkSession (which copies the full conversation history), this builds a
+   * fresh message list carrying only the system prompt, runtime context, AGENTS.md
+   * instructions, and the approved plan — so implementation starts from a clean
+   * context while file history stays traceable to the source session's checkpoint.
+   */
+  startPlanImplementationSession(sourceSessionId: string, planText: string): string {
+    const source = this.getSession(sourceSessionId);
+    if (!source) {
+      throw new Error(`No saved session found with ID "${sourceSessionId}".`);
+    }
+
+    const sourceMessages = this.listSessionMessages(sourceSessionId);
+    const sourceMessage = sourceMessages.at(-1);
+    if (!sourceMessage || typeof sourceMessage.id !== "string" || !sourceMessage.id) {
+      throw new Error(`Session "${sourceSessionId}" has no messages to derive from.`);
+    }
+
+    const sessionId = crypto.randomUUID();
+    const now = new Date().toISOString();
+    const entry: SessionEntry = {
+      id: sessionId,
+      summary: source.summary,
+      assistantReply: null,
+      assistantThinking: null,
+      assistantRefusal: null,
+      toolCalls: null,
+      status: "completed",
+      failReason: null,
+      usage: null,
+      usagePerModel: null,
+      activeTokens: 0,
+      createTime: now,
+      updateTime: now,
+      processes: null,
+      planMode: false,
+      forkedFrom: {
+        sessionId: sourceSessionId,
+        messageId: sourceMessage.id,
+      },
+    };
+
+    const promptToolOptions = this.getPromptToolOptions();
+    const messages: SessionMessage[] = [
+      this.buildSystemMessage(sessionId, getSystemPrompt(this.projectRoot, promptToolOptions)),
+      this.buildSystemMessage(
+        sessionId,
+        getRuntimeContext(
+          this.projectRoot,
+          promptToolOptions.model,
+          this.getResolvedSettings().permissions?.addWorkingDirs
+        )
+      ),
+    ];
+
+    const agentInstructions = this.loadAgentInstructions();
+    if (agentInstructions) {
+      messages.push(this.buildSystemMessage(sessionId, agentInstructions));
+    }
+
+    messages.push(
+      this.buildSystemMessage(sessionId, `<proposed_plan>\n${planText}\n</proposed_plan>`, null, false, {
+        isSummary: true,
+      })
+    );
+
+    this.saveSessionMessages(sessionId, messages);
+    this.getFileHistory().forkSession(sourceSessionId, sessionId);
+
+    const index = this.loadSessionsIndex();
+    index.entries.push(entry);
+    const sortedEntries = index.entries.slice().sort((a, b) => {
+      const aTime = Date.parse(a.updateTime);
+      const bTime = Date.parse(b.updateTime);
+      if (Number.isNaN(aTime) || Number.isNaN(bTime)) {
+        return b.updateTime.localeCompare(a.updateTime);
+      }
+      return bTime - aTime;
+    });
+    const keptEntries = sortedEntries.slice(0, MAX_SESSION_ENTRIES);
+    const keptIds = new Set(keptEntries.map((item) => item.id));
+    const droppedEntries = sortedEntries.filter((item) => !keptIds.has(item.id));
+    index.entries = keptEntries;
+    this.saveSessionsIndex(index);
+    for (const dropped of droppedEntries) {
+      this.cleanupSessionResources(dropped.id, {
+        removeMessages: true,
+        processIds: this.getProcessIds(dropped.processes ?? null),
+      });
+    }
+
+    return sessionId;
+  }
+
+  /**
    * Delete a session by its ID.
    * Removes the session entry from the index and cleans up associated resources
    * such as message files, in-memory state caches, working directory state,

--- a/packages/core/src/tests/session.test.ts
+++ b/packages/core/src/tests/session.test.ts
@@ -9,7 +9,13 @@ import sharp from "sharp";
 import { GitFileHistory } from "../common/file-history";
 import { clearSessionState } from "../common/state";
 import { getSystemPrompt } from "../prompt";
-import { getProjectCode, SessionManager, type SessionMessage } from "../session";
+import {
+  buildPlanImplementationHandoff,
+  extractProposedPlan,
+  getProjectCode,
+  SessionManager,
+  type SessionMessage,
+} from "../session";
 import type { MultimodalMode } from "../common/model-capabilities";
 
 const originalFetch = globalThis.fetch;
@@ -3891,10 +3897,10 @@ test("SessionManager persists session and user message before skill matching is 
 
   await manager.handleUserPrompt({ text: "please use demo" });
 
-  // Session and user message are persisted before skill matching triggers an abort.
+  // The new session is active and persisted before skill matching triggers an abort.
   assert.equal(manager.listSessions().length, 1);
   const [session] = manager.listSessions();
-  assert.equal(session?.status, "pending");
+  assert.equal(session?.status, "interrupted");
   const messages = manager.listSessionMessages(session!.id);
   const userMessage = messages.find((m) => m.role === "user");
   assert.equal(userMessage?.content, "please use demo");
@@ -4080,6 +4086,24 @@ test("SessionManager.deleteSession removes the messages file", () => {
 
   // Verify messages file is removed
   assert.equal(fs.existsSync(messagePath), false);
+});
+
+test("SessionManager.deleteSession removes the file history reference", () => {
+  if (!hasGit()) {
+    return;
+  }
+
+  const workspace = createTempDir("deepcode-delete-history-workspace-");
+  const home = createTempDir("deepcode-delete-history-home-");
+  setHomeDir(home);
+  const manager = createSessionManager(workspace, "machine-id-delete-history");
+  const sessionId = createSessionAndMessages(manager, "session-delete-history", "Test session");
+  const fileHistory = new GitFileHistory(workspace, getFileHistoryGitDir(home, workspace));
+  assert.ok(fileHistory.ensureSession(sessionId));
+
+  manager.deleteSession(sessionId);
+
+  assert.equal(fileHistory.getCurrentCheckpointHash(sessionId), undefined);
 });
 
 test("sessions persist pasted images as file URLs without changing user content", async () => {
@@ -4618,7 +4642,17 @@ test("SessionManager.forkSession copies conversation state with fresh usage and 
   assert.equal(fileHistory.getCurrentCheckpointHash(sourceSessionId), sourceCheckpoint);
 });
 
-test("SessionManager.startPlanImplementationSession derives a clean context with the approved plan", () => {
+test("plan handoff helpers preserve the latest complete proposed plan", () => {
+  assert.equal(
+    extractProposedPlan("<proposed_plan>First</proposed_plan>\n<proposed_plan>\nSecond plan\n</proposed_plan>"),
+    "Second plan"
+  );
+  assert.equal(extractProposedPlan("<proposed_plan>Incomplete"), null);
+  assert.equal(extractProposedPlan("<proposed_plan>\n</proposed_plan>"), null);
+  assert.match(buildPlanImplementationHandoff("Build it"), /<proposed_plan>\nBuild it\n<\/proposed_plan>$/);
+});
+
+test("SessionManager.startPlanImplementationSession derives a trusted clean context with exact provenance", async () => {
   if (!hasGit()) {
     return;
   }
@@ -4654,11 +4688,23 @@ test("SessionManager.startPlanImplementationSession derives a clean context with
       id: "source-head-message",
       sessionId: sourceSessionId,
       role: "assistant",
-      content: "<proposed_plan>\nOld plan\n</proposed_plan>",
+      content: "<proposed_plan>\nBuild a thing\nwith two steps.\n</proposed_plan>",
       contentParams: null,
       messageParams: null,
       compacted: false,
       visible: true,
+      createTime: now,
+      updateTime: now,
+    },
+    {
+      id: "trailing-tool-message",
+      sessionId: sourceSessionId,
+      role: "system",
+      content: "Later tool output",
+      contentParams: null,
+      messageParams: null,
+      compacted: false,
+      visible: false,
       createTime: now,
       updateTime: now,
     },
@@ -4672,7 +4718,7 @@ test("SessionManager.startPlanImplementationSession derives a clean context with
   assert.ok(sourceCheckpoint);
 
   const planText = "Build a thing\nwith two steps.";
-  const sessionId = manager.startPlanImplementationSession(sourceSessionId, planText);
+  const { sessionId, implementationPrompt } = await manager.startPlanImplementationSession(sourceSessionId, planText);
   const derived = manager.getSession(sessionId);
   assert.ok(derived);
   assert.equal(derived.summary, "Plan source");
@@ -4681,28 +4727,33 @@ test("SessionManager.startPlanImplementationSession derives a clean context with
   assert.equal(derived.usagePerModel, null);
   assert.equal(derived.activeTokens, 0);
   assert.equal(derived.status, "completed");
-  assert.deepEqual(derived.forkedFrom, {
+  assert.equal(derived.forkedFrom, undefined);
+  assert.deepEqual(derived.derivedFrom, {
+    kind: "plan-implementation",
     sessionId: sourceSessionId,
     messageId: "source-head-message",
   });
 
   const messages = manager.listSessionMessages(sessionId);
-  assert.equal(messages.length, 3);
+  assert.equal(messages.length, 2);
   assert.ok(messages.every((message) => message.role === "system"));
   assert.ok(!messages.some((message) => message.id === "source-user-message" || message.id === "source-head-message"));
-  const planMessage = messages.at(-1)!;
-  assert.equal(planMessage.visible, false);
-  assert.equal(planMessage.meta?.isPlan, true);
   assert.equal(
-    planMessage.content,
+    implementationPrompt,
     `A previous agent produced the plan below to accomplish the user's task. Implement the plan in a fresh context. Treat the plan as the source of user intent, re-read files as needed, and carry the work through implementation and verification.\n\n<proposed_plan>\n${planText}\n</proposed_plan>`
   );
+  assert.equal(messages.filter((message) => message.content?.includes(planText)).length, 0);
 
   assert.equal(fileHistory.getCurrentCheckpointHash(sessionId), sourceCheckpoint);
   assert.deepEqual(manager.listSessionMessages(sourceSessionId), sourceMessages);
+
+  const repeated = await manager.startPlanImplementationSession(sourceSessionId, planText);
+  assert.notEqual(repeated.sessionId, sessionId);
+  assert.equal(manager.getSession(sourceSessionId)?.summary, "Plan source");
+  assert.deepEqual(manager.getSession(repeated.sessionId)?.derivedFrom, derived.derivedFrom);
 });
 
-test("SessionManager.startPlanImplementationSession rejects a source session that is not in Plan Mode", () => {
+test("SessionManager.startPlanImplementationSession rejects a source session that is not in Plan Mode", async () => {
   if (!hasGit()) {
     return;
   }
@@ -4713,10 +4764,13 @@ test("SessionManager.startPlanImplementationSession rejects a source session tha
   const manager = createSessionManager(workspace, "machine-id-plan-impl-nonplan");
   const sourceSessionId = createSessionAndMessages(manager, "source-session", "Not a plan session");
 
-  assert.throws(() => manager.startPlanImplementationSession(sourceSessionId, "Build a thing."), /is not in Plan Mode/);
+  await assert.rejects(
+    manager.startPlanImplementationSession(sourceSessionId, "Build a thing."),
+    /is not in Plan Mode/
+  );
 });
 
-test("SessionManager.startPlanImplementationSession rejects an empty plan text", () => {
+test("SessionManager.startPlanImplementationSession rejects an empty plan text", async () => {
   if (!hasGit()) {
     return;
   }
@@ -4733,7 +4787,212 @@ test("SessionManager.startPlanImplementationSession rejects an empty plan text",
   };
   (manager as any).saveSessionsIndex(index);
 
-  assert.throws(() => manager.startPlanImplementationSession(sourceSessionId, "   \n"), /must not be empty/);
+  await assert.rejects(manager.startPlanImplementationSession(sourceSessionId, "   \n"), /must not be empty/);
+});
+
+test("SessionManager.startPlanImplementationSession rejects incomplete sources and stale plans", async () => {
+  const workspace = createTempDir("deepcode-plan-impl-validation-workspace-");
+  const home = createTempDir("deepcode-plan-impl-validation-home-");
+  setHomeDir(home);
+  const manager = createSessionManager(workspace, "machine-id-plan-impl-validation");
+  await assert.rejects(manager.startPlanImplementationSession("missing-session", "Plan"), /No saved session/);
+  const sourceSessionId = createSessionAndMessages(manager, "source-session", "Plan source");
+  const index = (manager as any).loadSessionsIndex();
+  index.entries[0] = { ...index.entries[0], planMode: true, status: "processing" };
+  (manager as any).saveSessionsIndex(index);
+
+  await assert.rejects(manager.startPlanImplementationSession(sourceSessionId, "Plan"), /is not completed/);
+  index.entries[0].status = "completed";
+  (manager as any).saveSessionsIndex(index);
+  await assert.rejects(manager.startPlanImplementationSession(sourceSessionId, "Plan"), /no complete proposed plan/);
+
+  const messages = manager.listSessionMessages(sourceSessionId);
+  messages.push({
+    ...messages.at(-1)!,
+    id: "approved-plan-message",
+    role: "assistant",
+    content: "<proposed_plan>Current plan</proposed_plan>",
+  });
+  (manager as any).saveSessionMessages(sourceSessionId, messages);
+  await assert.rejects(manager.startPlanImplementationSession(sourceSessionId, "Stale plan"), /no longer matches/);
+});
+
+test("SessionManager.startPlanImplementationSession rejects proposed plans without a valid message ID", async () => {
+  const workspace = createTempDir("deepcode-plan-impl-message-id-workspace-");
+  const home = createTempDir("deepcode-plan-impl-message-id-home-");
+  setHomeDir(home);
+  const manager = createSessionManager(workspace, "machine-id-plan-impl-message-id");
+  const sourceSessionId = createSessionAndMessages(manager, "source-session", "Plan source");
+  const index = (manager as any).loadSessionsIndex();
+  index.entries[0] = { ...index.entries[0], planMode: true, status: "completed" };
+  (manager as any).saveSessionsIndex(index);
+  const baseMessage = manager.listSessionMessages(sourceSessionId).at(-1)!;
+
+  for (const id of [undefined, null, "", "   ", 42]) {
+    (manager as any).saveSessionMessages(sourceSessionId, [
+      {
+        ...baseMessage,
+        id,
+        role: "assistant",
+        content: "<proposed_plan>Current plan</proposed_plan>",
+      },
+    ]);
+    await assert.rejects(
+      manager.startPlanImplementationSession(sourceSessionId, "Current plan"),
+      /without a valid message ID/
+    );
+  }
+});
+
+test("SessionManager.startPlanImplementationSession re-resolves a compact skill catalog", async () => {
+  const workspace = createTempDir("deepcode-plan-impl-skills-workspace-");
+  const home = createTempDir("deepcode-plan-impl-skills-home-");
+  setHomeDir(home);
+  const skillDir = path.join(workspace, ".agents", "skills", "deploy-skill");
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(skillDir, "SKILL.md"),
+    "---\nname: renamed-deploy-skill\ndescription: Current deployment guidance\n---\n# Secret full instructions\n",
+    "utf8"
+  );
+  const manager = createSessionManager(workspace, "machine-id-plan-impl-skills");
+  const sourceSessionId = createSessionAndMessages(manager, "source-session", "Plan source");
+  const index = (manager as any).loadSessionsIndex();
+  index.entries[0] = { ...index.entries[0], planMode: true, status: "completed" };
+  (manager as any).saveSessionsIndex(index);
+  const now = "2026-01-01T00:00:00.000Z";
+  const baseMessage = {
+    sessionId: sourceSessionId,
+    contentParams: null,
+    messageParams: null,
+    compacted: false,
+    visible: false,
+    createTime: now,
+    updateTime: now,
+  };
+  const sourceMessages: SessionMessage[] = [
+    {
+      ...baseMessage,
+      id: "old-catalog",
+      role: "system",
+      content: "Old catalog",
+      meta: {
+        skillCatalog: [
+          { name: "deploy-skill", description: "Stale description" },
+          { name: "removed-skill", description: "No longer installed" },
+        ],
+      },
+    },
+    {
+      ...baseMessage,
+      id: "loaded-skill",
+      role: "tool",
+      content: "FULL SKILL BODY MUST NOT COPY",
+      meta: {
+        skill: {
+          name: "deploy-skill",
+          path: "./.agents/skills/deploy-skill/SKILL.md",
+          description: "Stale description",
+          isLoaded: true,
+        },
+      },
+    },
+    {
+      ...baseMessage,
+      id: "malformed-catalog",
+      role: "system",
+      content: "Malformed catalog",
+      meta: { skillCatalog: { name: "not-an-array" } as any },
+    },
+    {
+      ...baseMessage,
+      id: "approved-plan",
+      role: "assistant",
+      content: "<proposed_plan>Deploy with deploy-skill</proposed_plan>",
+      visible: true,
+    },
+  ];
+  (manager as any).saveSessionMessages(sourceSessionId, sourceMessages);
+
+  const result = await manager.startPlanImplementationSession(sourceSessionId, "Deploy with deploy-skill");
+  const derivedMessages = manager.listSessionMessages(result.sessionId);
+  const catalog = derivedMessages.find((message) => message.meta?.skillCatalog)?.meta?.skillCatalog;
+  assert.deepEqual(catalog, [{ name: "renamed-deploy-skill", description: "Current deployment guidance" }]);
+  assert.doesNotMatch(derivedMessages.map((message) => message.content).join("\n"), /FULL SKILL BODY|Secret full/);
+
+  let matchedPrompt = "";
+  manager.identifyMatchingSkillNames = async (_skills, prompt) => {
+    matchedPrompt = prompt;
+    return ["renamed-deploy-skill"];
+  };
+  await manager.replySession(result.sessionId, { text: result.implementationPrompt, planMode: false });
+  assert.equal(matchedPrompt, result.implementationPrompt);
+  const submittedMessages = manager.listSessionMessages(result.sessionId);
+  assert.equal(
+    submittedMessages.filter(
+      (message) => message.role === "user" && message.content === result.implementationPrompt && message.visible
+    ).length,
+    1
+  );
+});
+
+test("SessionManager.startPlanImplementationSession removes partial state when creation fails", async () => {
+  if (!hasGit()) {
+    return;
+  }
+
+  const workspace = createTempDir("deepcode-plan-impl-cleanup-workspace-");
+  const home = createTempDir("deepcode-plan-impl-cleanup-home-");
+  setHomeDir(home);
+  const manager = createSessionManager(workspace, "machine-id-plan-impl-cleanup");
+  const sourceSessionId = createSessionAndMessages(manager, "source-session", "Plan source");
+  const index = (manager as any).loadSessionsIndex();
+  index.entries[0] = { ...index.entries[0], planMode: true, status: "completed" };
+  (manager as any).saveSessionsIndex(index);
+  const sourceMessages = manager.listSessionMessages(sourceSessionId);
+  (manager as any).saveSessionMessages(sourceSessionId, [
+    ...sourceMessages,
+    {
+      ...sourceMessages.at(-1)!,
+      id: "approved-plan",
+      role: "assistant",
+      content: "<proposed_plan>Current plan</proposed_plan>",
+    },
+  ]);
+  const fileHistory = new GitFileHistory(workspace, getFileHistoryGitDir(home, workspace));
+  fileHistory.ensureSession(sourceSessionId);
+  let derivedSessionId = "";
+  (manager as any).registerSessionEntry = (entry: { id: string }) => {
+    derivedSessionId = entry.id;
+    throw new Error("index write failed");
+  };
+
+  await assert.rejects(manager.startPlanImplementationSession(sourceSessionId, "Current plan"), /index write failed/);
+
+  const projectDir = path.join(home, ".deepcode", "projects", getProjectCode(workspace));
+  assert.ok(derivedSessionId);
+  assert.equal(manager.getSession(derivedSessionId), null);
+  assert.equal(fs.existsSync(path.join(projectDir, `${derivedSessionId}.jsonl`)), false);
+  assert.equal(fileHistory.getCurrentCheckpointHash(derivedSessionId), undefined);
+  assert.ok(fileHistory.getCurrentCheckpointHash(sourceSessionId));
+});
+
+test("SessionManager.createSession binds the active session before asynchronous skill matching", async () => {
+  const workspace = createTempDir("deepcode-create-session-active-workspace-");
+  const home = createTempDir("deepcode-create-session-active-home-");
+  setHomeDir(home);
+  const manager = createSessionManager(workspace, "machine-id-create-session-active");
+  (manager as any).activateSession = async () => {};
+  let matchingSessionId: string | undefined;
+  manager.identifyMatchingSkillNames = async (_skills, _prompt, options) => {
+    matchingSessionId = options?.sessionId;
+    assert.equal(manager.getActiveSessionId(), matchingSessionId);
+    return [];
+  };
+
+  const sessionId = await manager.createSession({ text: "Use a matching skill" });
+
+  assert.equal(matchingSessionId, sessionId);
 });
 
 test("SessionManager ignores malformed fork lineage in persisted entries", () => {
@@ -4749,6 +5008,21 @@ test("SessionManager ignores malformed fork lineage in persisted entries", () =>
   fs.writeFileSync(indexPath, JSON.stringify(persisted), "utf8");
 
   assert.equal(manager.getSession(sessionId)?.forkedFrom, undefined);
+});
+
+test("SessionManager tolerates malformed plan derivation metadata in persisted entries", () => {
+  const workspace = createTempDir("deepcode-plan-lineage-workspace-");
+  const home = createTempDir("deepcode-plan-lineage-home-");
+  setHomeDir(home);
+  const manager = createSessionManager(workspace, "machine-id-plan-lineage");
+  const sessionId = createSessionAndMessages(manager, "lineage-session", "Lineage");
+  const projectDir = (manager as any).getProjectStorage().projectDir;
+  const indexPath = path.join(projectDir, "sessions-index.json");
+  const persisted = JSON.parse(fs.readFileSync(indexPath, "utf8"));
+  persisted.entries[0].derivedFrom = { kind: "other", sessionId };
+  fs.writeFileSync(indexPath, JSON.stringify(persisted), "utf8");
+
+  assert.equal(manager.getSession(sessionId)?.derivedFrom, undefined);
 });
 
 test("SessionManager persists plugin rate limits with UnderstandImage priority and does not copy them to forks", () => {

--- a/packages/core/src/tests/session.test.ts
+++ b/packages/core/src/tests/session.test.ts
@@ -4618,6 +4618,87 @@ test("SessionManager.forkSession copies conversation state with fresh usage and 
   assert.equal(fileHistory.getCurrentCheckpointHash(sourceSessionId), sourceCheckpoint);
 });
 
+test("SessionManager.startPlanImplementationSession derives a clean context with the approved plan", () => {
+  if (!hasGit()) {
+    return;
+  }
+
+  const workspace = createTempDir("deepcode-plan-impl-workspace-");
+  const home = createTempDir("deepcode-plan-impl-home-");
+  setHomeDir(home);
+  const manager = createSessionManager(workspace, "machine-id-plan-impl");
+  const sourceSessionId = createSessionAndMessages(manager, "source-session", "Plan source");
+  const now = "2026-01-01T00:00:00.000Z";
+  const index = (manager as any).loadSessionsIndex();
+  index.entries[0] = {
+    ...index.entries[0],
+    summary: "Plan source",
+    planMode: true,
+  };
+  (manager as any).saveSessionsIndex(index);
+
+  const sourceMessages: SessionMessage[] = [
+    {
+      id: "source-user-message",
+      sessionId: sourceSessionId,
+      role: "user",
+      content: "Plan source",
+      contentParams: null,
+      messageParams: null,
+      compacted: false,
+      visible: true,
+      createTime: now,
+      updateTime: now,
+    },
+    {
+      id: "source-head-message",
+      sessionId: sourceSessionId,
+      role: "assistant",
+      content: "<proposed_plan>\nOld plan\n</proposed_plan>",
+      contentParams: null,
+      messageParams: null,
+      compacted: false,
+      visible: true,
+      createTime: now,
+      updateTime: now,
+    },
+  ];
+  (manager as any).saveSessionMessages(sourceSessionId, sourceMessages);
+
+  const trackedPath = path.join(workspace, "tracked.txt");
+  fs.writeFileSync(trackedPath, "source", "utf8");
+  const fileHistory = new GitFileHistory(workspace, getFileHistoryGitDir(home, workspace));
+  const sourceCheckpoint = fileHistory.recordCheckpoint(sourceSessionId, [trackedPath], "source checkpoint");
+  assert.ok(sourceCheckpoint);
+
+  const planText = "Build a thing\nwith two steps.";
+  const sessionId = manager.startPlanImplementationSession(sourceSessionId, planText);
+  const derived = manager.getSession(sessionId);
+  assert.ok(derived);
+  assert.equal(derived.summary, "Plan source");
+  assert.equal(derived.planMode, false);
+  assert.equal(derived.usage, null);
+  assert.equal(derived.usagePerModel, null);
+  assert.equal(derived.activeTokens, 0);
+  assert.equal(derived.status, "completed");
+  assert.deepEqual(derived.forkedFrom, {
+    sessionId: sourceSessionId,
+    messageId: "source-head-message",
+  });
+
+  const messages = manager.listSessionMessages(sessionId);
+  assert.equal(messages.length, 3);
+  assert.ok(messages.every((message) => message.role === "system"));
+  assert.ok(!messages.some((message) => message.id === "source-user-message" || message.id === "source-head-message"));
+  const planMessage = messages.at(-1)!;
+  assert.equal(planMessage.visible, false);
+  assert.equal(planMessage.meta?.isSummary, true);
+  assert.equal(planMessage.content, `<proposed_plan>\n${planText}\n</proposed_plan>`);
+
+  assert.equal(fileHistory.getCurrentCheckpointHash(sessionId), sourceCheckpoint);
+  assert.deepEqual(manager.listSessionMessages(sourceSessionId), sourceMessages);
+});
+
 test("SessionManager ignores malformed fork lineage in persisted entries", () => {
   const workspace = createTempDir("deepcode-fork-lineage-workspace-");
   const home = createTempDir("deepcode-fork-lineage-home-");

--- a/packages/core/src/tests/session.test.ts
+++ b/packages/core/src/tests/session.test.ts
@@ -4692,11 +4692,48 @@ test("SessionManager.startPlanImplementationSession derives a clean context with
   assert.ok(!messages.some((message) => message.id === "source-user-message" || message.id === "source-head-message"));
   const planMessage = messages.at(-1)!;
   assert.equal(planMessage.visible, false);
-  assert.equal(planMessage.meta?.isSummary, true);
-  assert.equal(planMessage.content, `<proposed_plan>\n${planText}\n</proposed_plan>`);
+  assert.equal(planMessage.meta?.isPlan, true);
+  assert.equal(
+    planMessage.content,
+    `A previous agent produced the plan below to accomplish the user's task. Implement the plan in a fresh context. Treat the plan as the source of user intent, re-read files as needed, and carry the work through implementation and verification.\n\n<proposed_plan>\n${planText}\n</proposed_plan>`
+  );
 
   assert.equal(fileHistory.getCurrentCheckpointHash(sessionId), sourceCheckpoint);
   assert.deepEqual(manager.listSessionMessages(sourceSessionId), sourceMessages);
+});
+
+test("SessionManager.startPlanImplementationSession rejects a source session that is not in Plan Mode", () => {
+  if (!hasGit()) {
+    return;
+  }
+
+  const workspace = createTempDir("deepcode-plan-impl-nonplan-workspace-");
+  const home = createTempDir("deepcode-plan-impl-nonplan-home-");
+  setHomeDir(home);
+  const manager = createSessionManager(workspace, "machine-id-plan-impl-nonplan");
+  const sourceSessionId = createSessionAndMessages(manager, "source-session", "Not a plan session");
+
+  assert.throws(() => manager.startPlanImplementationSession(sourceSessionId, "Build a thing."), /is not in Plan Mode/);
+});
+
+test("SessionManager.startPlanImplementationSession rejects an empty plan text", () => {
+  if (!hasGit()) {
+    return;
+  }
+
+  const workspace = createTempDir("deepcode-plan-impl-empty-workspace-");
+  const home = createTempDir("deepcode-plan-impl-empty-home-");
+  setHomeDir(home);
+  const manager = createSessionManager(workspace, "machine-id-plan-impl-empty");
+  const sourceSessionId = createSessionAndMessages(manager, "source-session", "Plan source");
+  const index = (manager as any).loadSessionsIndex();
+  index.entries[0] = {
+    ...index.entries[0],
+    planMode: true,
+  };
+  (manager as any).saveSessionsIndex(index);
+
+  assert.throws(() => manager.startPlanImplementationSession(sourceSessionId, "   \n"), /must not be empty/);
 });
 
 test("SessionManager ignores malformed fork lineage in persisted entries", () => {


### PR DESCRIPTION
## 结果

- 将已批准方案作为干净实现会话的第一条用户消息提交，并校验其来自已完成 Plan Mode 会话中最新、完整且具有有效消息 ID 的 `<proposed_plan>`。
- 以共享逻辑重建当前系统提示、运行上下文与 AGENTS.md，按名称或路径重新发现精简 skill 目录；派生失败和正常删除都会尽力清理消息与文件历史。
- 严格按活动会话 ID 隔离消息、状态、重试、权限与进程输出；选项 4 在首次选择后立即进入单次执行状态，准备失败时恢复源会话，提交失败历史则保留在派生会话。
- 使用结构化来源元数据展示独立的 `planned` / `implementation` 标记，并在 80 列终端中保证长标题不会挤坏徽章、状态或时间行。

Closes lessweb/deepcode-cli#325

## 验证

- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm test`（CLI 326/326；core 357 通过、1 个 Windows 专用用例在 macOS 跳过；VS Code 57/57）
- [x] GitHub Actions Node 22/24 × Linux/macOS/Windows 完整矩阵已运行：macOS 两项通过；Linux 仍仅有既有的 3 个权限路径基线失败（[Node 22](https://github.com/lessweb/deepcode-cli/actions/runs/33612994202/job/100192287992)、[Node 24](https://github.com/lessweb/deepcode-cli/actions/runs/33612994202/job/100192287981)）；Windows 仍仅有既有的 Plan Mode 临时目录权限基线失败（[Node 22](https://github.com/lessweb/deepcode-cli/actions/runs/33612994202/job/100192288364)、[Node 24](https://github.com/lessweb/deepcode-cli/actions/runs/33612994202/job/100192288082)），未发现本 PR 新增回归
- [x] 未提交 `dist/` 或 `package-lock.json` 变更

Co-authored-by: Codex <noreply@openai.com>

<details>
<summary>Accountability Index</summary>

| SHA | 做了什么 | 为什么 | 证据 |
| --- | --- | --- | --- |
| 2f8b1fa | 新增干净方案实现会话入口与文件历史派生 | 满足清理执行上下文、保留工作区与可撤销历史的需求 | [issue #325](https://github.com/lessweb/deepcode-cli/issues/325) |
| c3a605f | 在 Plan 批准界面加入第 4 个选项并接线 | 让用户显式选择干净上下文执行，同时保留原 3 个流程 | [PR commit](https://github.com/lessweb/deepcode-cli/pull/331/commits/c3a605f71ed3b97fdd0536a1bef0a610d5d0c549) |
| f635426 | 更新 Plan 文档与 README 命令表 | 使公开入口与 4 选项交互保持一致 | [PR commit](https://github.com/lessweb/deepcode-cli/pull/331/commits/f6354260133f8f1f0bc88440230eb05b854d9076) |
| 01ab326 | 增加 Plan Mode/非空校验和来源说明 | 收紧早期派生约束并说明方案来源 | [PR commit](https://github.com/lessweb/deepcode-cli/pull/331/commits/01ab3266aaab53668cfc33069f82ce589a16b7c9) |
| ee06bb7 | 保留失败选择器并加入临时标题标记 | 改善派生失败时的重试体验与会话辨识 | [PR commit](https://github.com/lessweb/deepcode-cli/pull/331/commits/ee06bb71e29eaf2cc646f491afce51c3f30bdb91) |
| 6f9f13c | 补充选项 4 的携带内容与 skill 说明 | 对齐首版行为的用户文档 | [PR commit](https://github.com/lessweb/deepcode-cli/pull/331/commits/6f9f13c77542ae45d5cea52eeb42ae42e947076f) |
| 0d65ea6 | 校验精确方案来源、共享可信前缀、重解析 skill 并清理失败派生 | 修复权限提升、陈旧或畸形 skill、无效来源与残留历史 | [PR commit](https://github.com/lessweb/deepcode-cli/pull/331/commits/0d65ea6bdf6e182455965ad5fde00ee53386156b) |
| 3b0c246 | 严格隔离会话事件、统一视图激活、防止重复提交并修正标题布局 | 防止后台源会话污染实现会话及长标题拆坏来源标记 | [PR commit](https://github.com/lessweb/deepcode-cli/pull/331/commits/3b0c246177c273720a24c7b9a6d53e1f71bc5b2d) |
| 70c98e8 | 精简中英文干净交接说明 | 只保留用户可观察的交接、重加载、可恢复和历史继承行为 | [PR commit](https://github.com/lessweb/deepcode-cli/pull/331/commits/70c98e8f6cbe857bfe9cc0ef92423d18a6f359b6) |

</details>
